### PR TITLE
Fix origin CCE - Fracciones arancelarias 2021

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,9 @@ jobs:
         env:
           fail-fast: true
       - name: Install xlsx2csv & libreoffice-calc
-        run: sudo apt-get install -y --no-install-recommends xlsx2csv default-jre-headless libreoffice-calc
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y -qq --no-install-recommends xlsx2csv default-jre-headless libreoffice-calc
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Get composer cache directory

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.4.1 2022-03-18
+
+Fix origin `CCE - Fracciones arancelarias 2021`, the link contains extra characters now.
+
 ## Version 2.4.0 2022-03-07
 
 Add CCP (*Complemento de Carta Porte*) 2.0 catalogs.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Version 2.4.1 2022-03-18
 
-Fix origin `CCE - Fracciones arancelarias 2021`, the link contains extra characters now.
+- Fix origin `CCE - Fracciones arancelarias 2021`, the link contains extra characters now.
+- CI: run `apt-get update` before install other packages.
 
 ## Version 2.4.0 2022-03-07
 

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -38,7 +38,7 @@ class DumpOrigins implements CommandInterface
                 'CCE - Fracciones arancelarias 2021',
                 'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/catalogos_emision_cfdi_complemento_ce.htm',
                 'c_FraccionArancelaria_2021.xls',
-                'Catálogo vigente a partir del 28 de diciembre de 2020',
+                '*Catálogo vigente a partir del 28 de diciembre de 2020*',
             ),
             new ConstantOrigin('CCE - Incoterms', "{$common}/c_INCOTERM.xls"),
             new ConstantOrigin('CCE - Localidades', "{$common}/c_Localidad.xls"),


### PR DESCRIPTION
The link contains extra characters now.

Extra: [CI] run `apt-get update` before install other packages.