### PR TITLE
Maintenance (v2.5.0)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,11 +13,16 @@
 /.phive/                    export-ignore
 /build/                     export-ignore
 /tests/                     export-ignore
+/.dockerignore              export-ignore
 /.gitattributes             export-ignore
 /.gitignore                 export-ignore
 /.php-cs-fixer.dist.php     export-ignore
 /.scrutinizer.yml           export-ignore
+/Docker.README.md           export-ignore
+/Dockerfile                 export-ignore
 /phpcs.xml.dist             export-ignore
 /phpstan.neon.dist          export-ignore
 /phpunit.xml.dist           export-ignore
-/psalm.xml.dist             export-ignore
+
+# Do not count these files on github code language
+/tests/_files/**            linguist-detectable=false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -56,7 +56,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           coverage: none
           extensions: sqlite3
           tools: composer:v2, cs2pr, phpstan
@@ -81,7 +81,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2']
+        php-versions: [8.1', '8.2']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
           coverage: none
-          tools: composer:v2, cs2pr, phpcs
+          tools: cs2pr, phpcs
         env:
           fail-fast: true
       - name: Code style (phpcs)
@@ -35,13 +35,13 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
           coverage: none
-          tools: composer:v2, cs2pr, php-cs-fixer
+          tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
@@ -52,7 +52,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -66,7 +66,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
@@ -81,10 +81,10 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1']
+        php-versions: ['8.0', '8.1', '8.2']
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -104,7 +104,7 @@ jobs:
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -4,4 +4,5 @@
   <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^1.9.1" installed="1.9.1" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.28.3" installed="2.28.3" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.8.0" installed="3.8.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.6.2" installed="3.6.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.6.2" installed="3.6.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.5.3" installed="1.5.3" location="./tools/phpstan" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.13.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.9.1" installed="1.9.1" location="./tools/phpstan" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,9 +15,7 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP73Migration' => true,
-    '@PHP74Migration' => true,
-    '@PHP80Migration' => true,
+        '@PHP80Migration' => true,
         '@PHP80Migration:risky' => true,
         // symfony
         'class_attributes_separation' => true,
@@ -25,11 +23,12 @@ return (new PhpCsFixer\Config())
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'function_typehint_space' => true,
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
         'phpdoc_scalar' => true,
-        'no_trailing_comma_in_singleline_array' => true,
+        'no_trailing_comma_in_singleline' => true,
         'single_quote' => true,
         'no_singleline_whitespace_before_semicolons' => true,
         'no_unused_imports' => true,
@@ -38,14 +37,16 @@ return (new PhpCsFixer\Config())
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
         // symfony:risky
+        'no_alias_functions' => true,
         'self_accessor' => true,
         // contrib
         'not_operator_with_successor_space' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const']], // @PSR12 sort_algorithm: none
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['vendor', 'tools', 'build']),
+            ->exclude(['tools', 'vendor', 'build'])
     )
 ;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,13 +81,13 @@ composer dev:build
 
 The following tests must pass before we will accept a pull request.
 If any of these do not pass, it will result in a complete build failure.
-Before you can run these, be sure to `composer install` or `composer update`.
+Before you can run these, be sure to `composer install` or `composer update` and `phive update`.
 
 ```shell script
-vendor/bin/php-cs-fixer fix --verbose
-vendor/bin/phpcbf --colors -sp
+tools/php-cs-fixer fix --verbose
+tools/phpcbf --colors -sp
 vendor/bin/phpunit --testdox
-vendor/bin/phpstan.phar analyse --no-progress --level max
+tools/phpstan analyse --no-progress --level max
 mkdir -p build/files/
 bin/sat-catalogos-update dump-origins > build/files/origins.xml
 bin/sat-catalogos-update update-origins build/files/ -w build/files/database.sqlite3

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [coverage]: https://scrutinizer-ci.com/g/phpcfdi/sat-catalogos-populate/code-structure/master/code-coverage/src
 
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/sat--catalogos--populate-blue?style=flat-square
-[badge-php-version]: https://img.shields.io/badge/php-^8.0-blue?style=flat-square
+[badge-php-version]: https://img.shields.io/badge/php-^8.1-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-catalogos-populate?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/sat-catalogos-populate?style=flat-square
 [badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/sat-catalogos-populate/build/master?style=flat-square

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # phpcfdi/sat-catalogos-populate
 
 [![Source Code][badge-source]][source]
+[![PHP Version][badge-php-version]][php-version]
 [![Latest Version][badge-release]][release]
 [![Software License][badge-license]][license]
 [![Build Status][badge-build]][build]
 [![Scrutinizer][badge-quality]][quality]
 [![Coverage Status][badge-coverage]][coverage]
-[![Total Downloads][badge-downloads]][downloads]
 
 > Herramienta para crear y actualizar los catálogos de SAT/CFDI en una base de datos SQLite3
 
@@ -21,8 +21,8 @@ the commands provided by this package, for more information check the [`README.D
 ```shell script
 git clone https://github.com/phpcfdi/sat-catalogos-populate.git
 docker build -t sat-catalogos-populate sat-catalogos-populate/
-docker run -it --rm sat-catalogos-populate /opt/bin/sat-catalogos-update --help
-``` 
+docker run -it --rm sat-catalogos-populate --help
+```
 
 ## Installation on local system
 
@@ -83,17 +83,17 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [todo]: https://github.com/phpcfdi/sat-catalogos-populate/blob/master/docs/TODO.md
 
 [source]: https://github.com/phpcfdi/sat-catalogos-populate
+[php-version]: https://github.com/phpcfdi/sat-catalogos-populate/blob/master/composer.json
 [release]: https://github.com/phpcfdi/sat-catalogos-populate/releases
 [license]: https://github.com/phpcfdi/sat-catalogos-populate/blob/master/LICENSE
 [build]: https://github.com/phpcfdi/sat-catalogos-populate/actions/workflows/build.yml?query=branch:master
 [quality]: https://scrutinizer-ci.com/g/phpcfdi/sat-catalogos-populate/
 [coverage]: https://scrutinizer-ci.com/g/phpcfdi/sat-catalogos-populate/code-structure/master/code-coverage/src
-[downloads]: https://github.com/phpcfdi/sat-catalogos-populate
 
 [badge-source]: https://img.shields.io/badge/source-phpcfdi/sat--catalogos--populate-blue?style=flat-square
+[badge-php-version]: https://img.shields.io/badge/php-^8.0-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-catalogos-populate?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/sat-catalogos-populate?style=flat-square
 [badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/sat-catalogos-populate/build/master?style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-catalogos-populate/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-catalogos-populate/master?style=flat-square
-[badge-downloads]: https://img.shields.io/github/downloads/phpcfdi/sat-catalogos-populate/total?style=flat-square

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         ],
         "dev:test": [
             "@dev:check-style",
-            "vendor/bin/phpunit --testdox --verbose --stop-on-failure",
+            "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
             "@php tools/phpstan analyse --no-progress --no-interaction"
         ],
         "dev:coverage": [

--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,12 @@
     "scripts": {
         "dev:build": ["@dev:fix-style", "@dev:test"],
         "dev:check-style": [
+            "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
         ],
         "dev:fix-style": [
+            "@php tools/composer-normalize normalize",
             "@php tools/php-cs-fixer fix --verbose",
             "@php tools/phpcbf --colors -sp"
         ],
@@ -64,8 +66,8 @@
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
-        "dev:check-style": "DEV: search for code style errors using php-cs-fixer and phpcs",
-        "dev:fix-style": "DEV: fix code style errors using php-cs-fixer and phpcbf",
+        "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
         "dev:test": "DEV: run dev:check-style, phpunit and phpstan",
         "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
     }

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
             "@php tools/phpstan analyse --no-progress --no-interaction"
         ],
         "dev:coverage": [
-            "@php -dzend_extension=xdebug.so vendor/bin/phpunit --coverage-text --coverage-html build/coverage/html/"
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --testdox --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "issues": "https://github.com/phpcfdi/sat-catalogos-populate/issues"
     },
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-pdo": "*",
         "ext-sqlite3": "*",
         "ext-json": "*",
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "phpunit/phpunit": "^9.1.5"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,33 @@
 {
     "name": "phpcfdi/sat-catalogos-populate",
     "description": "Herramienta para crear y actualizar los catálogos de SAT/CFDI en una base de datos SQLite3",
-    "keywords": ["sat", "cfdi", "catalogos"],
-    "homepage": "https://github.com/phpcfdi/sat-catalogos-populate",
     "license": "MIT",
+    "keywords": [
+        "sat",
+        "cfdi",
+        "catalogos"
+    ],
     "authors": [
         {
             "name": "Carlos C Soto",
             "email": "eclipxe13@gmail.com"
         }
     ],
+    "homepage": "https://github.com/phpcfdi/sat-catalogos-populate",
     "support": {
-        "source": "https://github.com/phpcfdi/sat-catalogos-populate",
-        "issues": "https://github.com/phpcfdi/sat-catalogos-populate/issues"
+        "issues": "https://github.com/phpcfdi/sat-catalogos-populate/issues",
+        "source": "https://github.com/phpcfdi/sat-catalogos-populate"
     },
     "require": {
         "php": ">=8.1",
-        "ext-pdo": "*",
-        "ext-sqlite3": "*",
-        "ext-json": "*",
-        "ext-simplexml": "*",
         "ext-dom": "*",
-        "psr/log": "^1.0",
+        "ext-json": "*",
+        "ext-pdo": "*",
+        "ext-simplexml": "*",
+        "ext-sqlite3": "*",
         "guzzlehttp/guzzle": "^7.0",
         "psr/http-message": "^1.0",
+        "psr/log": "^1.0",
         "symfony/dom-crawler": "^5.2"
     },
     "require-dev": {
@@ -44,11 +48,17 @@
         }
     },
     "scripts": {
-        "dev:build": ["@dev:fix-style", "@dev:test"],
+        "dev:build": [
+            "@dev:fix-style",
+            "@dev:test"
+        ],
         "dev:check-style": [
             "@php tools/composer-normalize normalize --dry-run",
             "@php tools/php-cs-fixer fix --dry-run --verbose",
             "@php tools/phpcs --colors -sp"
+        ],
+        "dev:coverage": [
+            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --testdox --coverage-html build/coverage/html/"
         ],
         "dev:fix-style": [
             "@php tools/composer-normalize normalize",
@@ -59,16 +69,13 @@
             "@dev:check-style",
             "@php vendor/bin/phpunit --testdox --verbose --stop-on-failure",
             "@php tools/phpstan analyse --no-progress --no-interaction"
-        ],
-        "dev:coverage": [
-            "@php -dzend_extension=xdebug.so -dxdebug.mode=coverage vendor/bin/phpunit --testdox --coverage-html build/coverage/html/"
         ]
     },
     "scripts-descriptions": {
         "dev:build": "DEV: run dev:fix-style and dev:tests, run before pull request",
         "dev:check-style": "DEV: search for code style errors using composer-normalize, php-cs-fixer and phpcs",
+        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/",
         "dev:fix-style": "DEV: fix code style errors using composer-normalize, php-cs-fixer and phpcbf",
-        "dev:test": "DEV: run dev:check-style, phpunit and phpstan",
-        "dev:coverage": "DEV: run phpunit with xdebug and storage coverage in build/coverage/html/"
+        "dev:test": "DEV: run dev:check-style, phpunit and phpstan"
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,20 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.5.0 2022-11-08
+
+- Fix PHPStan issue: `str_getcsv` can return `array<scalar|null>`.
+- Update signature for `SeekableIterator::seek`.
+- `UrlResponse` can have a `Stringable|string` body property.
+- Move logic to create a UrlResponse from a PSR Response
+- Bump to PHP 8.1.
+- Add badge for PHP 8.1.
+- Remove badge for downloads.
+- Upgrade development tools.
+- Update GH workflow:
+  - Add PHP 8.2 to test matrix.
+  - Update GH actions to 8.1.
+  - Remove composer requierement when not needed.
+
 ## Version 2.4.2 2022-04-01
 
 - Fix *Carta Porte 2.0* injector *ProductosServicios* headers.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Update GH actions to 8.1.
   - Remove composer requierement when not needed.
 - Fix composer script `dev:coverage`.
+- Implement development tool `composer-normalize`.
 
 ## Version 2.4.2 2022-04-01
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@
   - Add PHP 8.2 to test matrix.
   - Update GH actions to 8.1.
   - Remove composer requierement when not needed.
+- Fix composer script `dev:coverage`.
 
 ## Version 2.4.2 2022-04-01
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="EngineWorks">
-    <description>The EngineWorks (PSR-2 based) coding standard.</description>
+    <description>The EngineWorks (PSR-12 based) coding standard.</description>
 
     <file>bin</file>
     <file>src</file>

--- a/src/AbstractCsvInjector.php
+++ b/src/AbstractCsvInjector.php
@@ -20,7 +20,7 @@ abstract class AbstractCsvInjector implements InjectorInterface
 
     abstract public function dataTable(): DataTable;
 
-    public function __construct(private string $sourceFile)
+    public function __construct(private readonly string $sourceFile)
     {
     }
 

--- a/src/Commands/CliApplication.php
+++ b/src/Commands/CliApplication.php
@@ -57,7 +57,7 @@ class CliApplication
             return 0;
         }
 
-        if (count(array_intersect(['-h', '--help'], $arguments)) > 0) {
+        if ([] !== array_intersect(['-h', '--help'], $arguments)) {
             $this->showHelp($command);
             return 0;
         }

--- a/src/Commands/UpdateOrigins.php
+++ b/src/Commands/UpdateOrigins.php
@@ -27,8 +27,8 @@ class UpdateOrigins implements CommandInterface
 
     public function __construct(
         string $originsFile,
-        private bool $updateOrigins,
-        private string $databaseLocation,
+        private readonly bool $updateOrigins,
+        private readonly string $databaseLocation,
         private LoggerInterface $logger
     ) {
         if ('' === $originsFile) {

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -49,9 +49,9 @@ class CsvFolderJoinFiles
                     $file = basename($path);
                     $matches = [];
                     if (
-                        ! (bool) preg_match('/^[ ]*(.+)_Parte_([0-9]+)[ ]*\.csv$/', $file, $matches)
-                        && ! (bool) preg_match('/^[ ]*(.+) \(Parte ([0-9]+)\)[ ]*\.csv$/', $file, $matches)
-                        && ! (bool) preg_match('/^[ ]*(.+)_([0-9]+)[ ]*\.csv$/', $file, $matches)
+                        ! preg_match('/^ *(.+)_Parte_([0-9]+) *\.csv$/', $file, $matches)
+                        && ! preg_match('/^ *(.+) \(Parte ([0-9]+)\) *\.csv$/', $file, $matches)
+                        && ! preg_match('/^ *(.+)_([0-9]+) *\.csv$/', $file, $matches)
                     ) {
                         return [];
                     }
@@ -65,7 +65,7 @@ class CsvFolderJoinFiles
             )
         );
 
-        uasort($files, [$this, 'compareFiles']);
+        uasort($files, $this->compareFiles(...));
 
         $destinations = [];
         foreach ($files as $file) {

--- a/src/Database/AbstractDataField.php
+++ b/src/Database/AbstractDataField.php
@@ -12,10 +12,10 @@ abstract class AbstractDataField implements DataFieldInterface
     /**
      * @param callable|null $transformFunction
      */
-    public function __construct(private string $name, callable $transformFunction = null)
+    public function __construct(private readonly string $name, callable $transformFunction = null)
     {
         if (null === $transformFunction) {
-            $transformFunction = fn ($input): string => trim($input);
+            $transformFunction = fn ($input): string => trim((string) $input);
         }
         $this->transformFunction = $transformFunction;
     }

--- a/src/Database/BoolDataField.php
+++ b/src/Database/BoolDataField.php
@@ -12,11 +12,11 @@ class BoolDataField extends AbstractDataField implements DataFieldInterface
      */
     public function __construct(
         string $name,
-        private array $trueValues = [],
-        private array $falseValues = [],
-        private bool $default = false
+        private readonly array $trueValues = [],
+        private readonly array $falseValues = [],
+        private readonly bool $default = false
     ) {
-        parent::__construct($name, [$this, 'valueToBoolean']);
+        parent::__construct($name, $this->valueToBoolean(...));
     }
 
     /** @param scalar $input */

--- a/src/Database/DataTableGateway.php
+++ b/src/Database/DataTableGateway.php
@@ -9,7 +9,7 @@ use PDOException;
 
 class DataTableGateway
 {
-    public function __construct(private DataTable $dataTable, private Repository $repository)
+    public function __construct(private readonly DataTable $dataTable, private readonly Repository $repository)
     {
     }
 

--- a/src/Importers/Cce/CceFraccionArancelaria.php
+++ b/src/Importers/Cce/CceFraccionArancelaria.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 
 class CceFraccionArancelaria extends AbstractXlsOneSheetImporter
 {
-    public function __construct(private bool $recreateTable)
+    public function __construct(private readonly bool $recreateTable)
     {
     }
 

--- a/src/Importers/Cce/Injectors/FraccionesArancelarias.php
+++ b/src/Importers/Cce/Injectors/FraccionesArancelarias.php
@@ -19,7 +19,7 @@ class FraccionesArancelarias extends AbstractCsvInjector
     /** @param bool $shouldRecreateTable Indicates if the injector must recreate the table */
     public function __construct(
         string $sourceFile,
-        private bool $shouldRecreateTable
+        private readonly bool $shouldRecreateTable
     ) {
         parent::__construct($sourceFile);
     }

--- a/src/Importers/Nomina/Injectors/TiposOtrosPagos.php
+++ b/src/Importers/Nomina/Injectors/TiposOtrosPagos.php
@@ -19,7 +19,7 @@ class TiposOtrosPagos extends AbstractCsvInjector
     {
         $csv->move(3);
         $expected = [
-            ' c_TipoOtroPago', // WTF!!! tiene un espacio al inicio
+            ' c_TipoOtroPago', // WTF! has white space at the beginning
             'Descripción',
             'Fecha inicio de vigencia',
             'Fecha fin de vigencia',

--- a/src/Importers/SourcesImporter.php
+++ b/src/Importers/SourcesImporter.php
@@ -26,7 +26,7 @@ class SourcesImporter implements ImporterInterface
             'CCP 2.0' => ['source' => $source . '/CatalogosCartaPorte20.xls', 'importer' => new Ccp20Catalogs()],
         ];
 
-        foreach ($importers as $name => $info) {
+        foreach ($importers as $info) {
             $sourceFile = $info['source'];
             if (! file_exists($sourceFile)) {
                 throw new RuntimeException("Se esperaba encontrar $sourceFile pero no existe");

--- a/src/Origins/ConstantOrigin.php
+++ b/src/Origins/ConstantOrigin.php
@@ -13,8 +13,8 @@ class ConstantOrigin implements OriginInterface
     private string $destinationFilename;
 
     public function __construct(
-        private string $name,
-        private string $url,
+        private readonly string $name,
+        private readonly string $url,
         private ?DateTimeImmutable $lastVersion = null,
         string $destinationFilename = ''
     ) {

--- a/src/Origins/ConstantReviewer.php
+++ b/src/Origins/ConstantReviewer.php
@@ -8,7 +8,7 @@ use LogicException;
 
 class ConstantReviewer implements ReviewerInterface
 {
-    public function __construct(private ResourcesGatewayInterface $gateway)
+    public function __construct(private readonly ResourcesGatewayInterface $gateway)
     {
     }
 

--- a/src/Origins/Review.php
+++ b/src/Origins/Review.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
 class Review
 {
-    public function __construct(private OriginInterface $origin, private ReviewStatus $status)
+    public function __construct(private readonly OriginInterface $origin, private readonly ReviewStatus $status)
     {
     }
 

--- a/src/Origins/ReviewStatus.php
+++ b/src/Origins/ReviewStatus.php
@@ -12,7 +12,7 @@ class ReviewStatus
 
     protected const NOT_UPDATED = 'NOT-UPDATED';
 
-    private function __construct(private string $status)
+    private function __construct(private readonly string $status)
     {
     }
 

--- a/src/Origins/ScrapingOrigin.php
+++ b/src/Origins/ScrapingOrigin.php
@@ -10,10 +10,10 @@ use LogicException;
 class ScrapingOrigin implements OriginInterface
 {
     public function __construct(
-        private string $name,
-        private string $toScrapUrl,
-        private string $destinationFilename,
-        private string $linkText,
+        private readonly string $name,
+        private readonly string $toScrapUrl,
+        private readonly string $destinationFilename,
+        private readonly string $linkText,
         private ?DateTimeImmutable $lastVersion = null,
         private string $downloadUrl = ''
     ) {

--- a/src/Origins/ScrapingReviewer.php
+++ b/src/Origins/ScrapingReviewer.php
@@ -9,7 +9,7 @@ use RuntimeException;
 
 class ScrapingReviewer implements ReviewerInterface
 {
-    public function __construct(private ResourcesGatewayInterface $gateway)
+    public function __construct(private readonly ResourcesGatewayInterface $gateway)
     {
     }
 

--- a/src/Origins/ScrapingReviewerLinkExtractor.php
+++ b/src/Origins/ScrapingReviewerLinkExtractor.php
@@ -10,7 +10,7 @@ use Symfony\Component\DomCrawler\Link;
 
 final class ScrapingReviewerLinkExtractor
 {
-    public function __construct(private Crawler $crawler)
+    public function __construct(private readonly Crawler $crawler)
     {
     }
 

--- a/src/Origins/Upgrader.php
+++ b/src/Origins/Upgrader.php
@@ -10,12 +10,12 @@ use Psr\Log\LoggerInterface;
 
 class Upgrader
 {
-    public const DEFAULT_ORIGINS_FILENAME = 'origins.xml';
+    final public const DEFAULT_ORIGINS_FILENAME = 'origins.xml';
 
     public function __construct(
-        private ResourcesGatewayInterface $gateway,
-        private string $destinationPath,
-        private LoggerInterface $logger
+        private readonly ResourcesGatewayInterface $gateway,
+        private readonly string $destinationPath,
+        private readonly LoggerInterface $logger
     ) {
     }
 

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -12,16 +12,13 @@ class UrlResponse
 {
     private DateTimeImmutable $lastModified;
 
-    private Stringable|string $body;
-
     public function __construct(
-        private string $url,
-        private int $httpStatus,
+        private readonly string $url,
+        private readonly int $httpStatus,
         DateTimeImmutable $lastModified = null,
-        Stringable|string $body = ''
+        private readonly Stringable|string $body = ''
     ) {
         $this->lastModified = ($lastModified) ?: new DateTimeImmutable();
-        $this->body = $body;
     }
 
     public static function createFromResponse(ResponseInterface $response, string $url): self

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -6,18 +6,22 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
 use DateTimeImmutable;
 use Psr\Http\Message\ResponseInterface;
+use Stringable;
 
 class UrlResponse
 {
     private DateTimeImmutable $lastModified;
 
+    private Stringable|string $body;
+
     public function __construct(
         private string $url,
         private int $httpStatus,
         DateTimeImmutable $lastModified = null,
-        private string $body = ''
+        Stringable|string $body = ''
     ) {
         $this->lastModified = ($lastModified) ?: new DateTimeImmutable();
+        $this->body = $body;
     }
 
     public static function createFromResponse(ResponseInterface $response, string $url): self
@@ -28,7 +32,7 @@ class UrlResponse
             $lastModified = new DateTimeImmutable($response->getHeaderLine('Last-Modified'));
         }
 
-        return new self($url, $response->getStatusCode(), $lastModified, (string) $response->getBody());
+        return new self($url, $response->getStatusCode(), $lastModified, $response->getBody());
     }
 
     public function url(): string
@@ -58,6 +62,6 @@ class UrlResponse
 
     public function body(): string
     {
-        return $this->body;
+        return (string) $this->body;
     }
 }

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
 use DateTimeImmutable;
+use Psr\Http\Message\ResponseInterface;
 
 class UrlResponse
 {
@@ -17,6 +18,17 @@ class UrlResponse
         private string $body = ''
     ) {
         $this->lastModified = ($lastModified) ?: new DateTimeImmutable();
+    }
+
+    public static function createFromResponse(ResponseInterface $response, string $url): self
+    {
+        $lastModified = null;
+        if ($response->hasHeader('Last-Modified')) {
+            /** @noinspection PhpUnhandledExceptionInspection */
+            $lastModified = new DateTimeImmutable($response->getHeaderLine('Last-Modified'));
+        }
+
+        return new self($url, $response->getStatusCode(), $lastModified, (string) $response->getBody());
     }
 
     public function url(): string

--- a/src/Origins/WebResourcesGateway.php
+++ b/src/Origins/WebResourcesGateway.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
-use DateTimeImmutable;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
@@ -18,7 +17,7 @@ class WebResourcesGateway implements ResourcesGatewayInterface
 
     public function __construct(GuzzleClient $client = null)
     {
-        $this->client = ($client) ?: new GuzzleClient();
+        $this->client = $client ?? new GuzzleClient();
     }
 
     private function obtainResponse(string $method, string $url): ResponseInterface
@@ -41,13 +40,7 @@ class WebResourcesGateway implements ResourcesGatewayInterface
 
     private function createUrlResponseFromResponse(ResponseInterface $response, string $url): UrlResponse
     {
-        $lastModified = null;
-        if ($response->hasHeader('Last-Modified')) {
-            /** @noinspection PhpUnhandledExceptionInspection */
-            $lastModified = new DateTimeImmutable($response->getHeaderLine('Last-Modified'));
-        }
-
-        return new UrlResponse($url, $response->getStatusCode(), $lastModified, strval($response->getBody()));
+        return UrlResponse::createFromResponse($response, $url);
     }
 
     public function headers(string $url): UrlResponse

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -132,10 +132,7 @@ class CsvFile implements SeekableIterator
         $this->file->rewind();
     }
 
-    /**
-     * @param int $offset
-     */
-    public function seek($offset): void
+    public function seek(int $offset): void
     {
         $this->move($offset);
     }

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -108,7 +108,11 @@ class CsvFile implements SeekableIterator
         }
         $contents = $this->file->current();
         $contents = (! is_string($contents)) ? '' : $contents;
-        return $this->rowProcessor->execute(str_getcsv($contents));
+        $values = array_map(
+            fn ($value) => (is_scalar($value)) ? $value : '',
+            str_getcsv($contents)
+        );
+        return $this->rowProcessor->execute($values);
     }
 
     /** @return array<int, scalar> */

--- a/src/Utils/ShellExec.php
+++ b/src/Utils/ShellExec.php
@@ -8,7 +8,7 @@ class ShellExec
 {
     /** @param string[] $output */
     public function __construct(
-        private string $command,
+        private readonly string $command,
         private array $output = [],
         private int $exitStatus = -1,
         private string $lastLine = ''

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -25,7 +25,7 @@ class ImportTest extends TestCase
         /* mock this object to avoid expensive converter operation from a real file */
         /** @var CfdiCatalogs&MockObject $importer */
         $importer = $this->getMockBuilder(CfdiCatalogs::class)
-            ->setMethods(['createConverter'])
+            ->onlyMethods(['createConverter'])
             ->getMock();
         $importer->method('createConverter')->willReturn(new FakeXlsToCsvFolder($csvFolder));
 

--- a/tests/Fixtures/Converters/FakeXlsToCsvFolder.php
+++ b/tests/Fixtures/Converters/FakeXlsToCsvFolder.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Converters\XlsToCsvFolderConverter;
  */
 class FakeXlsToCsvFolder extends XlsToCsvFolderConverter
 {
-    public function __construct(private string $baseCsvFolder)
+    public function __construct(private readonly string $baseCsvFolder)
     {
     }
 

--- a/tests/Unit/Database/DataFieldsTest.php
+++ b/tests/Unit/Database/DataFieldsTest.php
@@ -38,6 +38,7 @@ class DataFieldsTest extends TestCase
         $this->expectExceptionMessage('There is a datafield with invalid type');
         /** @var DataFieldInterface&stdClass $fake Override declaration to force phpstan pass */
         $fake = new stdClass();
+        /** @noinspection PhpParamsInspection */
         new DataFields([$fake]);
     }
 

--- a/tests/Unit/Database/DataTableGatewayTest.php
+++ b/tests/Unit/Database/DataTableGatewayTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 class DataTableGatewayTest extends TestCase
 {
-    protected \PhpCfdi\SatCatalogosPopulate\Database\Repository $repository;
+    protected Repository $repository;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/CceClavePedimentoTest.php
+++ b/tests/Unit/Importers/Cce/CceClavePedimentoTest.php
@@ -13,7 +13,7 @@ class CceClavePedimentoTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceClavePedimento();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(ClavesPedimentos::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceColoniaTest.php
+++ b/tests/Unit/Importers/Cce/CceColoniaTest.php
@@ -13,7 +13,7 @@ class CceColoniaTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceColonia();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(Colonias::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceEstadoTest.php
+++ b/tests/Unit/Importers/Cce/CceEstadoTest.php
@@ -13,7 +13,7 @@ class CceEstadoTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceEstado();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(Estados::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceFraccionArancelariaTest.php
+++ b/tests/Unit/Importers/Cce/CceFraccionArancelariaTest.php
@@ -13,7 +13,7 @@ class CceFraccionArancelariaTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceFraccionArancelaria(true);
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(FraccionesArancelarias::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceIncotermTest.php
+++ b/tests/Unit/Importers/Cce/CceIncotermTest.php
@@ -13,7 +13,7 @@ class CceIncotermTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceIncoterm();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(Incoterms::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceLocalidadTest.php
+++ b/tests/Unit/Importers/Cce/CceLocalidadTest.php
@@ -13,7 +13,7 @@ class CceLocalidadTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceLocalidad();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(Localidades::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceMotivoTrasladoTest.php
+++ b/tests/Unit/Importers/Cce/CceMotivoTrasladoTest.php
@@ -13,7 +13,7 @@ class CceMotivoTrasladoTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceMotivoTraslado();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(MotivosTraslado::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceMunicipioTest.php
+++ b/tests/Unit/Importers/Cce/CceMunicipioTest.php
@@ -13,7 +13,7 @@ class CceMunicipioTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceMunicipio();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(Municipios::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceTipoOperacionTest.php
+++ b/tests/Unit/Importers/Cce/CceTipoOperacionTest.php
@@ -13,7 +13,7 @@ class CceTipoOperacionTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceTipoOperacion();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(TiposOperacion::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/CceUnidadAduanaTest.php
+++ b/tests/Unit/Importers/Cce/CceUnidadAduanaTest.php
@@ -13,7 +13,7 @@ class CceUnidadAduanaTest extends TestCase
 {
     public function testImporterInstance(): void
     {
-        // no need to test in depth, abstract class and injector is been tested
+        // no need to test in depth, abstract class and injector has been tested
         $importer = new CceUnidadAduana();
         $this->assertInstanceOf(AbstractXlsOneSheetImporter::class, $importer);
         $this->assertInstanceOf(UnidadesAduana::class, $importer->createInjector(''));

--- a/tests/Unit/Importers/Cce/Injectors/ClavesPedimentosTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/ClavesPedimentosTest.php
@@ -17,7 +17,7 @@ class ClavesPedimentosTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\ClavesPedimentos $injector;
+    private ClavesPedimentos $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/ColoniasTest.php
@@ -18,7 +18,7 @@ class ColoniasTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Colonias $injector;
+    private Colonias $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/FraccionesArancelariasTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/FraccionesArancelariasTest.php
@@ -19,7 +19,7 @@ class FraccionesArancelariasTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\FraccionesArancelarias $injector;
+    private FraccionesArancelarias $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/IncotermsTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/IncotermsTest.php
@@ -18,7 +18,7 @@ class IncotermsTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Incoterms $injector;
+    private Incoterms $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/LocalidadesTest.php
@@ -19,7 +19,7 @@ class LocalidadesTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Localidades $injector;
+    private Localidades $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/MotivosTrasladoTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/MotivosTrasladoTest.php
@@ -18,7 +18,7 @@ class MotivosTrasladoTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\MotivosTraslado $injector;
+    private MotivosTraslado $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/TiposOperacionTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/TiposOperacionTest.php
@@ -17,7 +17,7 @@ class TiposOperacionTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\TiposOperacion $injector;
+    private TiposOperacion $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/UnidadesAduanaTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/UnidadesAduanaTest.php
@@ -19,7 +19,7 @@ class UnidadesAduanaTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\UnidadesAduana $injector;
+    private UnidadesAduana $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Ccp20CatalogsTest.php
+++ b/tests/Unit/Importers/Ccp20CatalogsTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
+use PhpCfdi\SatCatalogosPopulate\Importers\Ccp20\Injectors;
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp20Catalogs;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
-use PhpCfdi\SatCatalogosPopulate\Importers\Ccp20\Injectors;
 
 class Ccp20CatalogsTest extends TestCase
 {

--- a/tests/Unit/Importers/Cfdi/Injectors/AduanasTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/AduanasTest.php
@@ -16,7 +16,7 @@ class AduanasTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\Aduanas $injector;
+    private Aduanas $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/ClavesUnidadesTest.php
@@ -16,7 +16,7 @@ class ClavesUnidadesTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\ClavesUnidades $injector;
+    private ClavesUnidades $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/CodigosPostalesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/CodigosPostalesTest.php
@@ -18,7 +18,7 @@ class CodigosPostalesTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\CodigosPostales $injector;
+    private CodigosPostales $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/MetodosDePagoTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/MetodosDePagoTest.php
@@ -17,7 +17,7 @@ class MetodosDePagoTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\MetodosDePago $injector;
+    private MetodosDePago $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/MonedasTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/MonedasTest.php
@@ -18,7 +18,7 @@ class MonedasTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\Monedas $injector;
+    private Monedas $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/ProductosServiciosTest.php
@@ -15,7 +15,7 @@ class ProductosServiciosTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\ProductosServicios $injector;
+    private ProductosServicios $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/TiposComprobantesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/TiposComprobantesTest.php
@@ -19,7 +19,7 @@ class TiposComprobantesTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\TiposComprobantes $injector;
+    private TiposComprobantes $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Cfdi/Injectors/TiposFactoresTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/TiposFactoresTest.php
@@ -17,7 +17,7 @@ class TiposFactoresTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\TiposFactores $injector;
+    private TiposFactores $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Nomina/Injectors/OrigenesRecursosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/OrigenesRecursosTest.php
@@ -17,7 +17,7 @@ class OrigenesRecursosTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\OrigenesRecursos $injector;
+    private OrigenesRecursos $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Nomina/Injectors/RiesgosPuestosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/RiesgosPuestosTest.php
@@ -18,7 +18,7 @@ class RiesgosPuestosTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\RiesgosPuestos $injector;
+    private RiesgosPuestos $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Importers/Nomina/Injectors/TiposNominasTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposNominasTest.php
@@ -17,7 +17,7 @@ class TiposNominasTest extends TestCase
 {
     private string $sourceFile;
 
-    private \PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\TiposNominas $injector;
+    private TiposNominas $injector;
 
     protected function setUp(): void
     {

--- a/tests/Unit/Origins/ConstantReviewerTest.php
+++ b/tests/Unit/Origins/ConstantReviewerTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
 class ConstantReviewerTest extends TestCase
 {
-    private \PhpCfdi\SatCatalogosPopulate\Origins\ConstantReviewer $reviewer;
+    private ConstantReviewer $reviewer;
 
     protected function setUp(): void
     {
@@ -24,7 +24,7 @@ class ConstantReviewerTest extends TestCase
 
     public function testAcceptsWithValidObject(): void
     {
-        $origin = new ConstantOrigin('Foo', 'http://foo/foo');
+        $origin = new ConstantOrigin('Foo', 'https://foo/foo');
         $this->assertTrue($this->reviewer->accepts($origin));
     }
 

--- a/tests/Unit/Origins/ScrapingReviewerTest.php
+++ b/tests/Unit/Origins/ScrapingReviewerTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
 class ScrapingReviewerTest extends TestCase
 {
-    private \PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewer $reviewer;
+    private ScrapingReviewer $reviewer;
 
     protected function setUp(): void
     {
@@ -24,7 +24,7 @@ class ScrapingReviewerTest extends TestCase
 
     public function testAcceptsWithValidObject(): void
     {
-        $origin = new ScrapingOrigin('Foo', 'http://foo/', 'foo.txt', 'foo');
+        $origin = new ScrapingOrigin('Foo', 'https://foo/', 'foo.txt', 'foo');
         $this->assertTrue($this->reviewer->accepts($origin));
     }
 


### PR DESCRIPTION
- Fix PHPStan issue: `str_getcsv` can return `array<scalar|null>`.
- Update signature for `SeekableIterator::seek`.
- `UrlResponse` can have a `Stringable|string` body property.
- Move logic to create a UrlResponse from a PSR Response
- Bump to PHP 8.1.
- Add badge for PHP 8.1.
- Remove badge for downloads.
- Upgrade development tools.
- Update GH workflow:
  - Add PHP 8.2 to test matrix.
  - Update GH actions to 8.1.
  - Remove composer requierement when not needed.
- Fix composer script `dev:coverage`.
- Implement development tool `composer-normalize`.
