### PR TITLE
Release version 2.6.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -39,13 +39,15 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpstan:
     name: Code analysis (phpstan)
@@ -56,7 +58,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
           extensions: sqlite3
           tools: composer:v2, cs2pr, phpstan

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.13.0" installed="3.13.0" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.1" installed="3.7.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.1" installed="3.7.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.9.1" installed="1.9.1" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.28.3" installed="2.28.3" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.2" installed="1.10.2" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.29.0" installed="2.29.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2022 PHPCFDI
+Copyright (c) 2019 - 2023 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ and licensed for use under the MIT License (MIT). Please see [LICENSE][] for mor
 [badge-php-version]: https://img.shields.io/badge/php-^8.1-blue?style=flat-square
 [badge-release]: https://img.shields.io/github/release/phpcfdi/sat-catalogos-populate?style=flat-square
 [badge-license]: https://img.shields.io/github/license/phpcfdi/sat-catalogos-populate?style=flat-square
-[badge-build]: https://img.shields.io/github/workflow/status/phpcfdi/sat-catalogos-populate/build/master?style=flat-square
+[badge-build]: https://img.shields.io/github/actions/workflow/status/phpcfdi/sat-catalogos-populate/build.yml?branch=master&style=flat-square
 [badge-quality]: https://img.shields.io/scrutinizer/g/phpcfdi/sat-catalogos-populate/master?style=flat-square
 [badge-coverage]: https://img.shields.io/scrutinizer/coverage/g/phpcfdi/sat-catalogos-populate/master?style=flat-square

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
-## Version 2.5.2 2022-12-12
+## Version 2.5.3 2022-12-12
 
 The catalog *CCE - Fracciones arancelarias* is composed of 3 different catalogs:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,30 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.6.0 2023-02-24
+
+Add *RET20 - CFDI de retenciones e información de pagos*, includes X different catalogs:
+
+- *Catálogo de claves de retenciones*.
+- *Catálogo de periodos*.
+- *Catálogo de ejercicios*.
+- *Catálogo de tipos de pago de la retención*.
+- *Catálogo de entidades federativas*.
+- *Catálogo de países*.
+- *Catálogo de periodicidades*.
+- *Catálogo de tipos de contribuyentes sujetos a retención*.
+- *Catálogo de tipos de dividendos o utilidades distribuidas*.
+- *Catálogo de tipo de impuesto*.
+
+Thanks `@gam04` for your contribution.
+
+The following changes to the project does not change the source code:
+
+- Update license year. Happy 2023!.
+- Fix build badge `badge-build`.
+- Fix changelog versions.
+- The GitHub workflow jobs run using PHP 8.2.
+- Update development tools.
+
 ## Version 2.5.3 2022-12-12
 
 The catalog *CCE - Fracciones arancelarias* is composed of 3 different catalogs:
@@ -9,7 +34,7 @@ The catalog *CCE - Fracciones arancelarias* is composed of 3 different catalogs:
 - *Catálogo vigente a partir del 12 de diciembre de 2022*.
 
 This update create the catalog `cce_fracciones_arancelarias` by inserting or replacing the catalogs one after another.
-Using this method, if an harmonized tariff schedule is found, it will override the previous record.
+Using this method, if a harmonized tariff schedule is found, it will override the previous record.
 
 Other minor changes:
 

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -33,9 +33,7 @@ class DumpOrigins implements CommandInterface
                 'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/CFDI_retenciones.htm',
                 'ret_20.xls',
                 'Catálogos',
-                null,
-                '',
-                1
+                linkPosition: 1,
             ),
             new ConstantOrigin('Nóminas', "{$common}/catNomina.xls"),
             new ConstantOrigin('Nóminas - Estados', "{$common}/C_Estado.xls", null, 'nominas_estados.xls'),

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -54,8 +54,7 @@ final class OriginsTranslator implements OriginsTranslatorInterface
             strval($data['destination-file'] ?? ''),
             strval($data['link-text'] ?? ''),
             $this->dateTimeFromStringOrNull(strval($data['last-update'] ?? '')),
-            '',
-            intval($data['link-position'] ?? 0),
+            linkPosition: intval($data['link-position'] ?? 0),
         );
     }
 


### PR DESCRIPTION
Add *RET20 - CFDI de retenciones e información de pagos*, includes X different catalogs:

- *Catálogo de claves de retenciones*.
- *Catálogo de periodos*.
- *Catálogo de ejercicios*.
- *Catálogo de tipos de pago de la retención*.
- *Catálogo de entidades federativas*.
- *Catálogo de países*.
- *Catálogo de periodicidades*.
- *Catálogo de tipos de contribuyentes sujetos a retención*.
- *Catálogo de tipos de dividendos o utilidades distribuidas*.
- *Catálogo de tipo de impuesto*.

Thanks `@gam04` for your contribution.

The following changes to the project does not change the source code:

- Update license year. Happy 2023!.
- Fix build badge `badge-build`.
- Fix changelog versions.
- The GitHub workflow jobs run using PHP 8.2.
- Update development tools.