### PR TITLE
Fix RET20 origin (version 1.6.1)

### DIFF
--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.14.4" installed="3.14.4" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.15.1" installed="3.15.1" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.2" installed="1.10.2" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.29.0" installed="2.29.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpstan" version="^1.10.10" installed="1.10.10" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.30.2" installed="2.30.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 2.6.0 2023-02-24
 
-Add *RET20 - CFDI de retenciones e información de pagos*, includes X different catalogs:
+Add *RET20 - CFDI de retenciones e información de pagos*, includes 10 different catalogs:
 
 - *Catálogo de claves de retenciones*.
 - *Catálogo de periodos*.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.6.1 2023-04-02
+
+- Update *RET20 - CFDI de retenciones e información de pagos* origin.
+- Improve error detection and message when a scraping link is not found.
+- Update development tools.
+
 ## Version 2.6.0 2023-02-24
 
 Add *RET20 - CFDI de retenciones e información de pagos*, includes 10 different catalogs:

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -33,7 +33,6 @@ class DumpOrigins implements CommandInterface
                 'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/CFDI_retenciones.htm',
                 'ret_20.xls',
                 'Catálogos',
-                linkPosition: 1,
             ),
             new ConstantOrigin('Nóminas', "{$common}/catNomina.xls"),
             new ConstantOrigin('Nóminas - Estados', "{$common}/C_Estado.xls", null, 'nominas_estados.xls'),

--- a/src/Origins/ScrapingReviewerLinkExtractor.php
+++ b/src/Origins/ScrapingReviewerLinkExtractor.php
@@ -42,10 +42,10 @@ final class ScrapingReviewerLinkExtractor
                 ('' !== $text = $linkElement->text('')) && fnmatch($search, $text, FNM_CASEFOLD)
         );
 
-        if ($elements->count() > 0) {
+        if ($elements->count() > $position) {
             return $elements->eq($position)->link();
         }
 
-        throw new RuntimeException(sprintf('Link text "%s" was not found', $search));
+        throw new RuntimeException(sprintf('Link text "%s" [%d] was not found', $search, $position));
     }
 }


### PR DESCRIPTION
- Update *RET20 - CFDI de retenciones e información de pagos* origin.
- Improve error detection and message when a scraping link is not found.
- Update development tools.
