### PR TITLE
Maintenance 2023-05-25 (Version 2.6.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,6 @@ jobs:
           fail-fast: true
       - name: Code style (php-cs-fixer)
         run: php-cs-fixer fix --dry-run --format=checkstyle | cs2pr
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: 1
 
   phpstan:
     name: Code analysis (phpstan)

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.15.1" installed="3.15.1" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.17.0" installed="3.17.0" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.10" installed="1.10.10" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.30.2" installed="2.30.2" location="./tools/composer-normalize" copy="false"/>
+  <phar name="phpstan" version="^1.10.15" installed="1.10.15" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.31.0" installed="2.31.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.6.2 2023-05-25
+
+- Fix `OriginsTranslatorInterface::originFromArray` PHPDoc signature.
+  It now receives `array<string, string>` instead of `array<string, mixed>`.
+
 ## Version 2.6.1 2023-04-02
 
 - Update *RET20 - CFDI de retenciones e información de pagos* origin.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `OriginsTranslatorInterface::originFromArray` PHPDoc signature.
   It now receives `array<string, string>` instead of `array<string, mixed>`.
+- Remove environment variable `PHP_CS_FIXER_IGNORE_ENV` on workflow `build.yml` job `php-cs-fixer`.
 
 ## Version 2.6.1 2023-04-02
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `OriginsTranslatorInterface::originFromArray` PHPDoc signature.
   It now receives `array<string, string>` instead of `array<string, mixed>`.
 - Remove environment variable `PHP_CS_FIXER_IGNORE_ENV` on workflow `build.yml` job `php-cs-fixer`.
+- Update development tools.
 
 ## Version 2.6.1 2023-04-02
 

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -22,7 +22,7 @@ final class OriginsTranslator implements OriginsTranslatorInterface
         throw new RuntimeException("Unable to create an origin with type $type");
     }
 
-    /** @param array<string, mixed> $data */
+    /** @param array<string, string> $data */
     public function constantOriginFromArray(array $data): ConstantOrigin
     {
         return new ConstantOrigin(
@@ -45,7 +45,7 @@ final class OriginsTranslator implements OriginsTranslatorInterface
         throw new RuntimeException(sprintf('Unable to export an origin with type %s', $origin::class));
     }
 
-    /** @param array<string, mixed> $data */
+    /** @param array<string, string> $data */
     public function scrapingOriginFromArray(array $data): ScrapingOrigin
     {
         return new ScrapingOrigin(

--- a/src/Origins/OriginsTranslatorInterface.php
+++ b/src/Origins/OriginsTranslatorInterface.php
@@ -6,6 +6,6 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
 interface OriginsTranslatorInterface
 {
-    /** @param array<string, mixed> $data */
+    /** @param array<string, string> $data */
     public function originFromArray(array $data): OriginInterface;
 }


### PR DESCRIPTION
- Fix `OriginsTranslatorInterface::originFromArray` PHPDoc signature.
  It now receives `array<string, string>` instead of `array<string, mixed>`.
- Remove environment variable `PHP_CS_FIXER_IGNORE_ENV` on workflow `build.yml` job `php-cs-fixer`.
- Update development tools.