### PR TITLE
Fix Anexo 20 scraping page location (version 2.6.4)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: build
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ "master" ]
   push:

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.20.0" installed="3.20.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.21.1" installed="3.21.1" location="./tools/php-cs-fixer" copy="false"/>
   <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
   <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.22" installed="1.10.22" location="./tools/phpstan" copy="false"/>
+  <phar name="phpstan" version="^1.10.24" installed="1.10.24" location="./tools/phpstan" copy="false"/>
   <phar name="composer-normalize" version="^2.32.0" installed="2.32.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -22,7 +22,7 @@ return (new PhpCsFixer\Config())
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
-        'function_typehint_space' => true,
+        'type_declaration_spaces' => true,
         'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 
 COPY . /opt/sat-catalogos-populate/
 
@@ -8,7 +8,7 @@ RUN set -e \
     && apt-get update -y \
     && apt-get dist-upgrade -y \
     # Install repository PHP from Ondřej Surý
-    && apt-get install -y apt-transport-https lsb-release ca-certificates curl \
+    && apt-get install -y lsb-release ca-certificates curl \
     && curl --no-progress-meter https://packages.sury.org/php/apt.gpg --output /etc/apt/trusted.gpg.d/php.gpg \
     && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list \
     && apt-get update -y \

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ The field now changes from boolean to integer.
 
 This field was interpreted as boolean, with value `true` when column value is `1`.
 The possible columns values are `0 - No aplica`, `1 - Estímulo frontera norte` and `2 - Estímulo frontera sur`. 
-Previously, the values `2` where inerpreted as `false`.
+Previously, the values `2` where interpreted as `false`.
 
 The sources specimens were changes to include data with values `0`, `1` and `2`.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ This change affects CFDI 3.3 and CFDI 4.0.
 
 Thanks `@TheSpectroMx` and `@FintaxDev`!
 
+Other development changes:
+
+- Update development tools.
+
 ## Version 2.6.3 2023-07-03
 
 Fix catalog *Códigos Postales* on CFDI 3.3 and CFDI 4.0 for column *Estímulo Franja Fronteriza*,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Thanks `@TheSpectroMx` and `@FintaxDev`!
 
 Other development changes:
 
+- Allow dispatch workflow manually.
 - Update `php-cs-fixer` configuration file.
 - Update development tools.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Thanks `@TheSpectroMx` and `@FintaxDev`!
 
 Other development changes:
 
+- Update docker image to Debian stable (*bookworm*).
 - Allow dispatch workflow manually.
 - Update `php-cs-fixer` configuration file.
 - Update development tools.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.6.4 2023-07-05
+
+Fix *Anexo 20* location, it was `http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm`
+and now it is `http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm`.
+This change affects CFDI 3.3 and CFDI 4.0.
+
+Thanks `@TheSpectroMx` and `@FintaxDev`!
+
 ## Version 2.6.3 2023-07-03
 
 Fix catalog *Códigos Postales* on CFDI 3.3 and CFDI 4.0 for column *Estímulo Franja Fronteriza*,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
-## Version 2.6.3 2023-06-03
+## Version 2.6.3 2023-07-03
 
 Fix catalog *Códigos Postales* on CFDI 3.3 and CFDI 4.0 for column *Estímulo Franja Fronteriza*,
 The field now changes from boolean to integer.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ Thanks `@TheSpectroMx` and `@FintaxDev`!
 
 Other development changes:
 
+- Update `php-cs-fixer` configuration file.
 - Update development tools.
 
 ## Version 2.6.3 2023-07-03

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -18,13 +18,13 @@ class DumpOrigins implements CommandInterface
         $origins = new Origins([
             new ScrapingOrigin(
                 'CFDI 3.3',
-                'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm',
+                'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm',
                 'catCFDI.xls',
                 'Catálogos CFDI Versión 3.3*',
             ),
             new ScrapingOrigin(
                 'CFDI 4.0',
-                'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm',
+                'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm',
                 'cfdi_40.xls',
                 'Catálogos CFDI Versión 4.0*',
             ),


### PR DESCRIPTION
Fix *Anexo 20* location, it was `http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20_version3-3.htm` and now it is `http://omawww.sat.gob.mx/tramitesyservicios/Paginas/anexo_20.htm`.
This change affects CFDI 3.3 and CFDI 4.0.

Thanks @TheSpectroMx and @FintaxDev!

Other development changes:

- Update docker image to Debian stable (*bookworm*).
- Allow dispatch workflow manually.
- Update `php-cs-fixer` configuration file.
- Update development tools.