### PR TITLE
Fix build [v2.7.1]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.21.1" installed="3.21.1" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.7.2" installed="3.7.2" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.7.2" installed="3.7.2" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.10.24" installed="1.10.24" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.32.0" installed="2.32.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.41.1" installed="3.41.1" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^3.8.0" installed="3.8.0" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^3.8.0" installed="3.8.0" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^1.10.50" installed="1.10.50" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.41.0" installed="2.41.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ As always, thanks to Ondřej Mirtes and PHPPStan team for saving our pitfails.
 
 Other development changes:
 
+- Add PHP 8.3 to test matrix.
 - Update development tools.
 
 ## Version 2.7.0 2023-10-22

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,16 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.7.1 2023-12-13
+
+PHPStan found an issue when creating commands using the method factory pattern.
+The *command* classes were able to extend and fail if method `::createFromArguments` was not overriden.
+More information: <https://github.com/phpstan/phpstan/issues/10286#issuecomment-1851590334>.
+As always, thanks to Ondřej Mirtes and PHPPStan team for saving our pitfails.
+
+Other development changes:
+
+- Update development tools.
+
 ## Version 2.7.0 2023-10-22
 
 Add CCP (*Complemento de Carta Porte*) 3.0 catalogs.

--- a/src/Commands/CliApplication.php
+++ b/src/Commands/CliApplication.php
@@ -65,6 +65,7 @@ class CliApplication
         return $this->runCommand($command, ...$arguments);
     }
 
+    /** @return class-string */
     public function getCommandClass(string $commandName): string
     {
         if (! isset($this->commands[$commandName])) {
@@ -76,8 +77,8 @@ class CliApplication
     public function runCommand(string $commandName, string ...$arguments): int
     {
         $commandClass = $this->getCommandClass($commandName);
-        /** @var callable $staticCallable phpstan work around*/
-        $staticCallable = $commandClass . '::createFromArguments';
+        /** @phpstan-var callable $staticCallable phpstan work around*/
+        $staticCallable = [$commandClass, 'createFromArguments'];
         /** @var CommandInterface $command */
         $command = call_user_func($staticCallable, $arguments);
         return $command->run();

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -10,7 +10,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\OriginsIO;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
 use Psr\Log\LoggerInterface;
 
-class DumpOrigins implements CommandInterface
+final class DumpOrigins implements CommandInterface
 {
     public function run(): int
     {

--- a/src/Commands/UpdateDatabase.php
+++ b/src/Commands/UpdateDatabase.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\SourcesImporter;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
-class UpdateDatabase implements CommandInterface
+final class UpdateDatabase implements CommandInterface
 {
     private string $sourceFolder;
 

--- a/src/Commands/UpdateOrigins.php
+++ b/src/Commands/UpdateOrigins.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\WebResourcesGateway;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
-class UpdateOrigins implements CommandInterface
+final class UpdateOrigins implements CommandInterface
 {
     private const DEFAULT_ORIGINS_FILENAME = 'origins.xml';
 


### PR DESCRIPTION
PHPStan found an issue when creating commands using the method factory pattern. The *command* classes were able to extend and fail if method `::createFromArguments` was not overriden.
More information: <https://github.com/phpstan/phpstan/issues/10286#issuecomment-1851590334>.
As always, thanks to Ondřej Mirtes and PHPPStan team for saving our pitfails.

Other development changes:

- Update development tools.
