### PR TITLE
PHP 8.4 compatibility and maintenance (version 2.10.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer-normalize
         env:
@@ -40,7 +40,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, phpcs
         env:
@@ -57,7 +57,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
           tools: cs2pr, php-cs-fixer
         env:
@@ -74,7 +74,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
           extensions: sqlite3
           tools: composer:v2, cs2pr, phpstan
@@ -95,7 +95,7 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-versions }}
+    name: Tests on PHP ${{ matrix.php-version }}
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
@@ -108,7 +108,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           coverage: xdebug
           extensions: sqlite3
           tools: composer:v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           fail-fast: true
       - name: Composer normalize
-        run: composer-normalize
+        run: composer-normalize --dry-run
 
   phpcs:
     name: Code Style (phpcs)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="php-cs-fixer" version="^3.59.3" installed="3.59.3" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^3.10.1" installed="3.10.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^3.10.1" installed="3.10.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="3.10.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="3.10.1" location="./tools/phpcbf" copy="false"/>
   <phar name="phpstan" version="^1.11.5" installed="1.11.5" location="./tools/phpstan" copy="false"/>
   <phar name="composer-normalize" version="^2.43.0" installed="2.43.0" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
-  <phar name="php-cs-fixer" version="^3.59.3" installed="3.59.3" location="./tools/php-cs-fixer" copy="false"/>
-  <phar name="phpcs" version="^4.0.1" installed="3.10.1" location="./tools/phpcs" copy="false"/>
-  <phar name="phpcbf" version="^4.0.1" installed="3.10.1" location="./tools/phpcbf" copy="false"/>
-  <phar name="phpstan" version="^1.11.5" installed="1.11.5" location="./tools/phpstan" copy="false"/>
-  <phar name="composer-normalize" version="^2.43.0" installed="2.43.0" location="./tools/composer-normalize" copy="false"/>
+  <phar name="php-cs-fixer" version="^3.92.0" installed="3.92.0" location="./tools/php-cs-fixer" copy="false"/>
+  <phar name="phpcs" version="^4.0.1" installed="4.0.1" location="./tools/phpcs" copy="false"/>
+  <phar name="phpcbf" version="^4.0.1" installed="4.0.1" location="./tools/phpcbf" copy="false"/>
+  <phar name="phpstan" version="^2.1.33" installed="2.1.33" location="./tools/phpstan" copy="false"/>
+  <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/composer-normalize" copy="false"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -15,15 +15,16 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP80Migration' => true,
-        '@PHP80Migration:risky' => true,
+        '@PHP8x2Migration' => true,
+        '@PHP8x2Migration:risky' => true,
         // symfony
+        'array_indentation' => true,
         'class_attributes_separation' => true,
         'whitespace_after_comma_in_array' => true,
         'no_empty_statement' => true,
         'no_extra_blank_lines' => true,
         'type_declaration_spaces' => true,
-        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['arrays']],
+        'trailing_comma_in_multiline' => ['after_heredoc' => true, 'elements' => ['array_destructuring', 'arrays', 'match', 'arguments', 'parameters']],
         'no_blank_lines_after_phpdoc' => true,
         'object_operator_without_whitespace' => true,
         'binary_operator_spaces' => true,
@@ -36,6 +37,8 @@ return (new PhpCsFixer\Config())
         'standardize_not_equals' => true,
         'concat_space' => ['spacing' => 'one'],
         'linebreak_after_opening_tag' => true,
+        'fully_qualified_strict_types' => true,
+        'global_namespace_import' => ['import_classes' => true],
         // symfony:risky
         'no_alias_functions' => true,
         'self_accessor' => true,
@@ -47,6 +50,6 @@ return (new PhpCsFixer\Config())
         PhpCsFixer\Finder::create()
             ->in(__DIR__)
             ->append([__FILE__])
-            ->exclude(['tools', 'vendor', 'build'])
+            ->exclude(['tools', 'vendor', 'build']),
     )
 ;

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,8 @@ RUN set -e \
     && apt-get update -y \
     && apt-get dist-upgrade -y \
     # Install repository PHP from Ondřej Surý \
-    && apt-get install -y lsb-release ca-certificates curl \
-    && curl --no-progress-meter https://packages.sury.org/php/apt.gpg --output /etc/apt/trusted.gpg.d/php.gpg \
-    && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list \
+    && apt install -y curl \
+    && curl --no-progress-meter https://packages.sury.org/php/README.txt | bash \
     && apt-get update -y \
     && apt-get dist-upgrade -y \
     # Install required packages \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN set -e \
     && apt-get install -y --no-install-recommends \
         libreoffice-calc-nogui default-jre-headless libreoffice-java-common \
     # Clean APT \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -e \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN set -e \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -e \
-    # Set up PHP \
-    && find /etc/php/ -type f -name "*.ini" -exec sed -i 's/^variables_order.*/variables_order=EGPCS/' "{}" \; \
+    # Set up PHP: variables_order & date.timezone \
+    && find /etc/php/ -type f -name "*.ini" -exec sed -i -E -e 's/^;?variables_order.*/variables_order=EGPCS/' -e 's#^;?date.timezone.*#date.timezone = America/Mexico_City#' "{}" \; \
     && php -i
 
 RUN set -e \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM debian:trixie
 
 COPY . /opt/sat-catalogos-populate/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,32 +4,32 @@ COPY . /opt/sat-catalogos-populate/
 
 RUN set -e \
     && export DEBIAN_FRONTEND=noninteractive \
-    # Update debian base system
+    # Update debian base system \
     && apt-get update -y \
     && apt-get dist-upgrade -y \
-    # Install repository PHP from Ondřej Surý
+    # Install repository PHP from Ondřej Surý \
     && apt-get install -y lsb-release ca-certificates curl \
     && curl --no-progress-meter https://packages.sury.org/php/apt.gpg --output /etc/apt/trusted.gpg.d/php.gpg \
     && echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/php.list \
     && apt-get update -y \
     && apt-get dist-upgrade -y \
-    # Install required packages
+    # Install required packages \
     && apt-get install -y \
         unzip git \
         xlsx2csv sqlite3 \
         php-cli php-curl php-zip php-sqlite3 php-xml \
     && apt-get install -y --no-install-recommends \
         libreoffice-calc-nogui default-jre-headless libreoffice-java-common \
-    # Clean APT
+    # Clean APT \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -e \
-    # Set up PHP
+    # Set up PHP \
     && find /etc/php/ -type f -name "*.ini" -exec sed -i 's/^variables_order.*/variables_order=EGPCS/' "{}" \; \
     && php -i
 
 RUN set -e \
-    # Install composer
+    # Install composer \
     && curl --progress-bar https://getcomposer.org/download/latest-stable/composer.phar --output /usr/local/bin/composer \
     && chmod +x /usr/local/bin/composer \
     && export COMPOSER_ALLOW_SUPERUSER=1 \

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 - 2024 PhpCfdi https://www.phpcfdi.com/
+Copyright (c) 2019 - 2026 PhpCfdi https://www.phpcfdi.com/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "phpunit/phpunit": "^10.5.5"
+        "phpunit/phpunit": "^11.5.46"
     },
     "autoload": {
         "psr-4": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,27 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 2.10.0 2026-01-08
+
+This is an update to make the code compatible with PHP 8.4.
+There are almost no compatibility backwards issues.
+
+Change license year to 2026.
+
+Other development changes:
+
+- Bump to PHPUnit 11.5.
+- Improve code using `rector/rector`.
+- Add PHP 8.4 to test matrix.
+- Run jobs using PHP 8.4 on GitHub workflows.
+- Fix `composer-normalize` workflow.
+- Update code standard for `phpcs` and `php-cs-fixer`.
+- Improve docker file:
+  - Run using Debian Trixie.
+  - Improve PHP installation.
+  - Clean APT packages.
+  - Set up PHP timezone variable.
+- Update development tools.
+
 ## Version 2.9.0 2024-06-19
 
 Add CCP (*Complemento de Carta Porte*) 3.1 catalogs.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="EngineWorks">
     <description>The EngineWorks (PSR-12 based) coding standard.</description>
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,7 +19,6 @@
     <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
-    <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.ConstructorName"/>
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,19 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     cacheDirectory="build/phpunit.cache"
     colors="true"
-    bootstrap="tests/bootstrap.php">
+    bootstrap="tests/bootstrap.php"
+    displayDetailsOnAllIssues="true"
+    >
     <testsuites>
         <testsuite name="Default">
-            <directory>./tests/</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory suffix=".php">./src/</directory>
+            <directory>src</directory>
         </include>
     </source>
 </phpunit>

--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -30,7 +30,7 @@ abstract class AbstractCollection implements Countable, IteratorAggregate
         foreach ($members as $index => $member) {
             if (! $this->isValidMember($member)) {
                 throw new InvalidArgumentException(
-                    "The member $index contains an object that is not valid for this collection"
+                    "The member $index contains an object that is not valid for this collection",
                 );
             }
         }
@@ -54,7 +54,7 @@ abstract class AbstractCollection implements Countable, IteratorAggregate
     {
         if (! isset($this->members[$index])) {
             throw new InvalidArgumentException(
-                "The collection does not contain the index $index"
+                "The collection does not contain the index $index",
             );
         }
 

--- a/src/Commands/CliApplication.php
+++ b/src/Commands/CliApplication.php
@@ -9,7 +9,20 @@ use RuntimeException;
 class CliApplication
 {
     /** @var array<string, array{class: class-string, description: string}> */
-    private array $commands;
+    private array $commands = [
+        'dump-origins' => [
+            'class' => DumpOrigins::class,
+            'description' => 'Hace un volcado del archivo de orígenes esperado',
+        ],
+        'update-origins' => [
+            'class' => UpdateOrigins::class,
+            'description' => 'Actualiza el archivo de orígenes desde un archivo o directorio',
+        ],
+        'update-database' => [
+            'class' => UpdateDatabase::class,
+            'description' => 'Actualiza la base de datos de catálogos desde un directorio',
+        ],
+    ];
 
     private string $executableName = '';
 
@@ -21,24 +34,6 @@ class CliApplication
     public function setExecutableName(string $executableName): void
     {
         $this->executableName = $executableName;
-    }
-
-    public function __construct()
-    {
-        $this->commands = [
-            'dump-origins' => [
-                'class' => DumpOrigins::class,
-                'description' => 'Hace un volcado del archivo de orígenes esperado',
-            ],
-            'update-origins' => [
-                'class' => UpdateOrigins::class,
-                'description' => 'Actualiza el archivo de orígenes desde un archivo o directorio',
-            ],
-            'update-database' => [
-                'class' => UpdateDatabase::class,
-                'description' => 'Actualiza la base de datos de catálogos desde un directorio',
-            ],
-        ];
     }
 
     public function run(string ...$arguments): int

--- a/src/Commands/CliApplication.php
+++ b/src/Commands/CliApplication.php
@@ -114,9 +114,11 @@ class CliApplication
         $commandClassName = $this->getCommandClass($commandName);
         $description = $this->commands[$commandName]['description'];
         echo $commandName, ': ', $description, PHP_EOL;
-        /** @var callable $staticCallable phpstan work around */
         $staticCallable = $commandClassName . '::help';
-        /** @var string $helpOutput */
+        /**
+         * @var string $helpOutput
+         * @phpstan-ignore-next-line
+         */
         $helpOutput = call_user_func($staticCallable, $commandName);
         echo $helpOutput, PHP_EOL, PHP_EOL;
     }

--- a/src/Commands/CliApplication.php
+++ b/src/Commands/CliApplication.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Commands;
 
 use RuntimeException;
 
-class CliApplication
+final class CliApplication
 {
     /** @var array<string, array{class: class-string, description: string}> */
     private array $commands = [

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -58,13 +58,13 @@ final class DumpOrigins implements CommandInterface
             new ConstantOrigin(
                 'CCE 1.1 - Fracciones arancelarias 2020',
                 "{$common}/c_FraccionArancelaria.xls",
-                destinationFilename: 'c_FraccionArancelaria_20170101.xls'
+                destinationFilename: 'c_FraccionArancelaria_20170101.xls',
             ),
             new ScrapingOrigin(
                 'CCE 1.1 - Fracciones arancelarias 20201228',
                 'http://omawww.sat.gob.mx/tramitesyservicios/Paginas/catalogos_emision_cfdi_complemento_ce.htm',
                 'c_FraccionArancelaria_20201228.xls',
-                '*Catálogo vigente del 28 de diciembre de 2020 al 11 de diciembre de 2022*'
+                '*Catálogo vigente del 28 de diciembre de 2020 al 11 de diciembre de 2022*',
             ),
             new ScrapingOrigin(
                 'CCE 1.1 - Fracciones arancelarias 20221212',

--- a/src/Commands/TerminalLogger.php
+++ b/src/Commands/TerminalLogger.php
@@ -24,7 +24,7 @@ class TerminalLogger extends AbstractLogger
         file_put_contents(
             'php://' . $streamName,
             date('Y-m-d H:i:s') . ' ' . $level . ': ' . $message . PHP_EOL,
-            FILE_APPEND
+            FILE_APPEND,
         );
     }
 

--- a/src/Commands/UpdateOrigins.php
+++ b/src/Commands/UpdateOrigins.php
@@ -29,7 +29,7 @@ final class UpdateOrigins implements CommandInterface
         string $originsFile,
         private readonly bool $updateOrigins,
         private readonly string $databaseLocation,
-        private LoggerInterface $logger
+        private LoggerInterface $logger,
     ) {
         if ('' === $originsFile) {
             throw new RuntimeException('Invalid origins: empty string received');
@@ -119,7 +119,7 @@ final class UpdateOrigins implements CommandInterface
                     $review->origin()->name(),
                     $review->origin()->downloadUrl(),
                     $review->origin()->destinationFilename(),
-                    $review->origin()->lastVersion()->format('c')
+                    $review->origin()->lastVersion()->format('c'),
                 ));
             }
         }
@@ -127,7 +127,7 @@ final class UpdateOrigins implements CommandInterface
             $this->logger->info(sprintf(
                 'El origen %s para %s no fue encontrado',
                 $review->origin()->name(),
-                $review->origin()->destinationFilename()
+                $review->origin()->destinationFilename(),
             ));
         }
         if ($notFoundReviews->count() > 0) {

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -146,7 +146,10 @@ class CsvFolderJoinFiles
     {
         // explode values, trim values, remove empty values at end and implode values back
         return implode(',', array_rtrim(
-            array_map(static fn (?string $value): string => trim($value ?? ''), str_getcsv($current)),
+            array_map(
+                static fn (string|null $value): string => trim($value ?? ''),
+                str_getcsv($current, escape: '\\'),
+            ),
         ));
     }
 

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -63,8 +63,8 @@ class CsvFolderJoinFiles
                         'source' => $path,
                     ];
                 },
-                glob($csvFolder . '/*.csv') ?: []
-            )
+                glob($csvFolder . '/*.csv') ?: [],
+            ),
         );
 
         uasort($files, $this->compareFiles(...));
@@ -146,7 +146,7 @@ class CsvFolderJoinFiles
     {
         // explode values, trim values, remove empty values at end and implode values back
         return implode(',', array_rtrim(
-            array_map(static fn (?string $value): string => trim($value ?? ''), str_getcsv($current))
+            array_map(static fn (?string $value): string => trim($value ?? ''), str_getcsv($current)),
         ));
     }
 

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -47,13 +47,13 @@ class CsvFolderJoinFiles
     {
         $files = array_filter(
             array_map(
-                function ($path): array {
+                function (string $path): array {
                     $file = basename($path);
                     $matches = [];
                     if (
-                        ! preg_match('/^ *(.+)_Parte_([0-9]+) *\.csv$/', $file, $matches)
-                        && ! preg_match('/^ *(.+) \(Parte ([0-9]+)\) *\.csv$/', $file, $matches)
-                        && ! preg_match('/^ *(.+)_([0-9]+) *\.csv$/', $file, $matches)
+                        ! preg_match('/^ *(.+)_Parte_(\d+) *\.csv$/', $file, $matches)
+                        && ! preg_match('/^ *(.+) \(Parte (\d+)\) *\.csv$/', $file, $matches)
+                        && ! preg_match('/^ *(.+)_(\d+) *\.csv$/', $file, $matches)
                     ) {
                         return [];
                     }

--- a/src/Converters/XlsToXlsxConverter.php
+++ b/src/Converters/XlsToXlsxConverter.php
@@ -60,7 +60,7 @@ class XlsToXlsxConverter
         $execution = ShellExec::run($command);
         if (0 !== $execution->exitStatus()) {
             throw new RuntimeException(
-                "Execution of soffice convertion return a non zero status code [{$execution->exitStatus()}]"
+                "Execution of soffice convertion return a non zero status code [{$execution->exitStatus()}]",
             );
         }
 

--- a/src/Converters/XlsxToCsvFolderConverter.php
+++ b/src/Converters/XlsxToCsvFolderConverter.php
@@ -51,7 +51,7 @@ class XlsxToCsvFolderConverter
         $execution = ShellExec::run($command);
         if (0 !== $execution->exitStatus()) {
             throw new RuntimeException(
-                "Execution of xlsx2csv conversion return a non zero status code [{$execution->exitStatus()}]"
+                "Execution of xlsx2csv conversion return a non zero status code [{$execution->exitStatus()}]",
             );
         }
 
@@ -79,7 +79,7 @@ class XlsxToCsvFolderConverter
         $execution = ShellExec::run($command);
         if (0 !== $execution->exitStatus()) {
             throw new RuntimeException(
-                "Remove trailing commas failed with code [{$execution->exitStatus()}] for file $csvFile"
+                "Remove trailing commas failed with code [{$execution->exitStatus()}] for file $csvFile",
             );
         }
     }

--- a/src/Database/AbstractDataField.php
+++ b/src/Database/AbstractDataField.php
@@ -12,7 +12,7 @@ abstract class AbstractDataField implements DataFieldInterface
     /**
      * @param (callable(scalar):scalar)|null $transformFunction
      */
-    public function __construct(private readonly string $name, ?callable $transformFunction = null)
+    public function __construct(private readonly string $name, callable|null $transformFunction = null)
     {
         if (null === $transformFunction) {
             $transformFunction = [$this, 'defaultTransformFunction'];

--- a/src/Database/AbstractDataField.php
+++ b/src/Database/AbstractDataField.php
@@ -6,16 +6,16 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 
 abstract class AbstractDataField implements DataFieldInterface
 {
-    /** @var callable */
+    /** @var callable(scalar):scalar */
     private $transformFunction;
 
     /**
-     * @param callable|null $transformFunction
+     * @param (callable(scalar):scalar)|null $transformFunction
      */
-    public function __construct(private readonly string $name, callable $transformFunction = null)
+    public function __construct(private readonly string $name, ?callable $transformFunction = null)
     {
         if (null === $transformFunction) {
-            $transformFunction = fn ($input): string => trim((string) $input);
+            $transformFunction = [$this, 'defaultTransformFunction'];
         }
         $this->transformFunction = $transformFunction;
     }
@@ -30,5 +30,11 @@ abstract class AbstractDataField implements DataFieldInterface
         /** @var scalar $value */
         $value = call_user_func($this->transformFunction, $input);
         return $value;
+    }
+
+    /** @param scalar $input */
+    private function defaultTransformFunction($input): string
+    {
+        return trim((string) $input);
     }
 }

--- a/src/Database/BoolDataField.php
+++ b/src/Database/BoolDataField.php
@@ -14,7 +14,7 @@ class BoolDataField extends AbstractDataField implements DataFieldInterface
         string $name,
         private readonly array $trueValues = [],
         private readonly array $falseValues = [],
-        private readonly bool $default = false
+        private readonly bool $default = false,
     ) {
         parent::__construct($name, $this->valueToBoolean(...));
     }

--- a/src/Database/DataFields.php
+++ b/src/Database/DataFields.php
@@ -25,6 +25,7 @@ class DataFields implements Countable, IteratorAggregate
     public function __construct(array $dataFields)
     {
         foreach ($dataFields as $dataField) {
+            /** @phpstan-ignore-next-line instanceof.alwaysTrue */
             if (! $dataField instanceof DataFieldInterface) {
                 throw new InvalidArgumentException('There is a datafield with invalid type');
             }

--- a/src/Database/DataTable.php
+++ b/src/Database/DataTable.php
@@ -22,7 +22,7 @@ class DataTable
         string $name,
         DataFields $fields,
         array $primaryKey = [],
-        bool $withoutPrimaryKey = false
+        bool $withoutPrimaryKey = false,
     ) {
         if ('' === $name) {
             throw new LogicException('The table name must not be empty');

--- a/src/Database/DataTableGateway.php
+++ b/src/Database/DataTableGateway.php
@@ -61,7 +61,7 @@ class DataTableGateway
             $pkDefinition = 'PRIMARY KEY ('
                 . implode(', ', array_map(
                     fn (string $input): string => $this->repository->escapeName($input),
-                    $this->dataTable->primaryKey()
+                    $this->dataTable->primaryKey(),
                 ))
                 . ')';
         }

--- a/src/Database/DateDataField.php
+++ b/src/Database/DateDataField.php
@@ -12,6 +12,7 @@ class DateDataField extends AbstractDataField implements DataFieldInterface
     public function __construct(string $name)
     {
         parent::__construct($name, function ($input) use ($name): string {
+            $input = strval($input);
             // empty string
             if ('' === $input) {
                 return '';

--- a/src/Database/NumberFormatDataField.php
+++ b/src/Database/NumberFormatDataField.php
@@ -8,7 +8,7 @@ class NumberFormatDataField extends TextDataField implements DataFieldInterface
 {
     public function __construct(string $name, int $decimals)
     {
-        parent::__construct($name, function ($input) use ($decimals) {
+        parent::__construct($name, function ($input) use ($decimals): string {
             if ('' === $input) {
                 return '';
             }

--- a/src/Database/Repository.php
+++ b/src/Database/Repository.php
@@ -47,14 +47,15 @@ class Repository
     {
         $stmt = $this->pdo->prepare($sql);
         if (false === $stmt->execute($values)) {
+            /** @var array{string, int, string} $errorInfo */
             $errorInfo = $stmt->errorInfo();
-            throw new PDOException(sprintf('[%s] %s', $errorInfo[1] ?? 'UNDEF', $errorInfo[2] ?? 'Unknown error'));
+            throw new PDOException(sprintf('[%s] %s', $errorInfo[1], $errorInfo[2]));
         }
     }
 
     /**
      * @param mixed[] $values
-     * @return array<int, array<string, string|null>>
+     * @return list<array<string, string|null>>
      */
     public function queryArray(string $sql, array $values = []): array
     {
@@ -109,14 +110,15 @@ class Repository
     }
 
     /**
-     * @param array<scalar|null> $values
-     * @return array<string|null>
+     * @template TKey
+     * @param array<TKey, scalar|null> $values
+     * @return array<TKey, string|null>
      */
     private function convertScalarNullToStringArray(array $values): array
     {
         return array_map(
             fn ($value): ?string => $this->convertScalarNullToStringValue($value),
-            $values
+            $values,
         );
     }
 }

--- a/src/Database/Repository.php
+++ b/src/Database/Repository.php
@@ -91,7 +91,7 @@ class Repository
     }
 
     /** @param array<string, scalar|null> $values */
-    public function queryOne(string $sql, array $values = []): ?string
+    public function queryOne(string $sql, array $values = []): string|null
     {
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute($values);
@@ -104,7 +104,7 @@ class Repository
     }
 
     /** @param scalar|null $value */
-    private function convertScalarNullToStringValue($value): ?string
+    private function convertScalarNullToStringValue($value): string|null
     {
         return (null === $value) ? null : (string) $value;
     }
@@ -117,7 +117,7 @@ class Repository
     private function convertScalarNullToStringArray(array $values): array
     {
         return array_map(
-            fn ($value): ?string => $this->convertScalarNullToStringValue($value),
+            fn ($value): string|null => $this->convertScalarNullToStringValue($value),
             $values,
         );
     }

--- a/src/Database/ToBeDefinedDataField.php
+++ b/src/Database/ToBeDefinedDataField.php
@@ -14,11 +14,11 @@ final class ToBeDefinedDataField extends PreprocessDataField
     /** @param string[] $toBeDefinedTexts */
     public function __construct(
         DataFieldInterface $nextDataField,
-        private readonly array $toBeDefinedTexts = ['Por definir']
+        private readonly array $toBeDefinedTexts = ['Por definir'],
     ) {
         parent::__construct(
             fn ($input) => $this->matchToBeDefined($input) ? '' : $input,
-            $nextDataField
+            $nextDataField,
         );
     }
 

--- a/src/Importers/Cce/Injectors/FraccionesArancelarias.php
+++ b/src/Importers/Cce/Injectors/FraccionesArancelarias.php
@@ -19,7 +19,7 @@ class FraccionesArancelarias extends AbstractCsvInjector
     /** @param bool $shouldRecreateTable Indicates if the injector must recreate the table */
     public function __construct(
         string $sourceFile,
-        private readonly bool $shouldRecreateTable
+        private readonly bool $shouldRecreateTable,
     ) {
         parent::__construct($sourceFile);
     }

--- a/src/Importers/Cfdi/Injectors/FormasDePago.php
+++ b/src/Importers/Cfdi/Injectors/FormasDePago.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors;
 
+use http\Exception\InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\BoolDataField;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;
@@ -47,7 +48,8 @@ class FormasDePago extends AbstractCsvInjector implements InjectorInterface
 
     public function dataTable(): DataTable
     {
-        $pattern = function (string $input): string {
+        $pattern = function ($input): string {
+            $input = is_scalar($input) ? strval($input) : throw new InvalidArgumentException('Unexpected input type');
             if ('No' === $input) {
                 return '';
             }

--- a/src/Importers/Cfdi/Injectors/NumerosPedimentoAduana.php
+++ b/src/Importers/Cfdi/Injectors/NumerosPedimentoAduana.php
@@ -49,7 +49,7 @@ class NumerosPedimentoAduana extends AbstractCsvInjector implements InjectorInte
                 new DateDataField('vigencia_hasta'),
             ]),
             [],
-            true
+            true,
         );
     }
 }

--- a/src/Importers/Cfdi/Injectors/Paises.php
+++ b/src/Importers/Cfdi/Injectors/Paises.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors;
 
+use http\Exception\InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;
 use PhpCfdi\SatCatalogosPopulate\Database\DataTable;
@@ -38,7 +39,8 @@ class Paises extends AbstractCsvInjector implements InjectorInterface
 
     public function dataTable(): DataTable
     {
-        $optionalPattern = function (string $input): string {
+        $optionalPattern = function ($input): string {
+            $input = is_scalar($input) ? strval($input) : throw new InvalidArgumentException('Unexpected input type');
             if ('' === $input) {
                 return '';
             }

--- a/src/Importers/Cfdi/Injectors/ReglasTasaCuota.php
+++ b/src/Importers/Cfdi/Injectors/ReglasTasaCuota.php
@@ -65,7 +65,7 @@ class ReglasTasaCuota extends AbstractCsvInjector implements InjectorInterface
                 new DateDataField('vigencia_hasta'),
             ]),
             [],
-            true
+            true,
         );
     }
 }

--- a/src/Importers/Cfdi40/Injectors/FormasDePago.php
+++ b/src/Importers/Cfdi40/Injectors/FormasDePago.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors;
 
+use http\Exception\InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\BoolDataField;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;
@@ -49,7 +50,8 @@ class FormasDePago extends AbstractCsvInjector implements InjectorInterface
 
     public function dataTable(): DataTable
     {
-        $pattern = function (string $input): string {
+        $pattern = function ($input): string {
+            $input = is_scalar($input) ? strval($input) : throw new InvalidArgumentException('Unexpected input type');
             if ('No' === $input) {
                 return '';
             }

--- a/src/Importers/Cfdi40/Injectors/NumerosPedimentoAduana.php
+++ b/src/Importers/Cfdi40/Injectors/NumerosPedimentoAduana.php
@@ -51,7 +51,7 @@ class NumerosPedimentoAduana extends AbstractCsvInjector implements InjectorInte
                 new DateDataField('vigencia_hasta'),
             ]),
             [],
-            true
+            true,
         );
     }
 }

--- a/src/Importers/Cfdi40/Injectors/Paises.php
+++ b/src/Importers/Cfdi40/Injectors/Paises.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors;
 
+use http\Exception\InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;
 use PhpCfdi\SatCatalogosPopulate\Database\DataTable;
@@ -39,7 +40,8 @@ class Paises extends AbstractCsvInjector implements InjectorInterface
 
     public function dataTable(): DataTable
     {
-        $optionalPattern = function (string $input): string {
+        $optionalPattern = function ($input): string {
+            $input = is_scalar($input) ? strval($input) : throw new InvalidArgumentException('Unexpected input type');
             if ('' === $input) {
                 return '';
             }

--- a/src/Importers/Cfdi40/Injectors/ReglasTasaCuota.php
+++ b/src/Importers/Cfdi40/Injectors/ReglasTasaCuota.php
@@ -67,7 +67,7 @@ class ReglasTasaCuota extends AbstractCsvInjector implements InjectorInterface
                 new DateDataField('vigencia_hasta'),
             ]),
             [],
-            true
+            true,
         );
     }
 }

--- a/src/Importers/SourcesImporter.php
+++ b/src/Importers/SourcesImporter.php
@@ -13,6 +13,7 @@ class SourcesImporter implements ImporterInterface
 {
     public function import(string $source, Repository $repository, LoggerInterface $logger): void
     {
+        /** @var array<string, array{source: non-empty-string, importer: ImporterInterface}> $importers */
         $importers = [
             'CFDI 3.3' => ['source' => $source . '/catCFDI.xls', 'importer' => new CfdiCatalogs()],
             'CFDI 4.0' => ['source' => $source . '/cfdi_40.xls', 'importer' => new Cfdi40Catalogs()],
@@ -38,7 +39,6 @@ class SourcesImporter implements ImporterInterface
         }
 
         foreach ($importers as $name => $info) {
-            /** @var ImporterInterface $importer */
             $sourceFile = $info['source'];
             $importer = $info['importer'];
             $logger->info("Importando $name desde $sourceFile...");

--- a/src/Origins/ConstantOrigin.php
+++ b/src/Origins/ConstantOrigin.php
@@ -16,7 +16,7 @@ class ConstantOrigin implements OriginInterface
         private readonly string $name,
         private readonly string $url,
         private ?DateTimeImmutable $lastVersion = null,
-        string $destinationFilename = ''
+        string $destinationFilename = '',
     ) {
         if ('' === $destinationFilename) {
             $destinationFilename = ltrim(parse_url($url, PHP_URL_PATH) ?: '', '/');

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -58,7 +58,7 @@ final class OriginsTranslator implements OriginsTranslatorInterface
         );
     }
 
-    public function dateTimeFromStringOrNull(string $value): ?DateTimeImmutable
+    public function dateTimeFromStringOrNull(string $value): DateTimeImmutable|null
     {
         /** @noinspection PhpUnhandledExceptionInspection */
         return ('' !== $value) ? new DateTimeImmutable($value) : null;

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -29,7 +29,7 @@ final class OriginsTranslator implements OriginsTranslatorInterface
             strval($data['name'] ?? ''),
             strval($data['href'] ?? ''),
             $this->dateTimeFromStringOrNull(strval($data['last-update'] ?? '')),
-            strval($data['destination-file'] ?? '')
+            strval($data['destination-file'] ?? ''),
         );
     }
 

--- a/src/Origins/ReviewStatus.php
+++ b/src/Origins/ReviewStatus.php
@@ -18,6 +18,7 @@ class ReviewStatus
 
     private static function staticObjects(string $type): self
     {
+        /** @var array<string, self> $objects */
         static $objects = [];
         if (! array_key_exists($type, $objects)) {
             $objects[$type] = new self($type);

--- a/src/Origins/ScrapingReviewerLinkExtractor.php
+++ b/src/Origins/ScrapingReviewerLinkExtractor.php
@@ -16,7 +16,7 @@ final readonly class ScrapingReviewerLinkExtractor
 
     public static function fromUrlResponse(UrlResponse $response): self
     {
-        if (empty($response->body())) {
+        if ('' === $response->body()) {
             throw new RuntimeException('Content is empty');
         }
         $crawler = new Crawler($response->body(), $response->url());
@@ -28,7 +28,7 @@ final readonly class ScrapingReviewerLinkExtractor
         $link = $this->selectLink($search, $position);
         $downloadUrl = $link->getUri();
 
-        if (empty($downloadUrl)) {
+        if ('' === $downloadUrl) {
             throw new RuntimeException('The link was found but it does not contains the url to download');
         }
 

--- a/src/Origins/ScrapingReviewerLinkExtractor.php
+++ b/src/Origins/ScrapingReviewerLinkExtractor.php
@@ -39,7 +39,7 @@ final readonly class ScrapingReviewerLinkExtractor
     {
         $elements = $this->crawler->filterXPath('//a')->reduce(
             fn (Crawler $linkElement): bool =>
-                ('' !== $text = $linkElement->text('')) && fnmatch($search, $text, FNM_CASEFOLD)
+                ('' !== $text = $linkElement->text('')) && fnmatch($search, $text, FNM_CASEFOLD),
         );
 
         if ($elements->count() > $position) {

--- a/src/Origins/Upgrader.php
+++ b/src/Origins/Upgrader.php
@@ -15,7 +15,7 @@ class Upgrader
     public function __construct(
         private readonly ResourcesGatewayInterface $gateway,
         private readonly string $destinationPath,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
     ) {
     }
 
@@ -86,7 +86,7 @@ class Upgrader
             'Actualizando %s desde %s en %s',
             $origin->name(),
             $origin->downloadUrl(),
-            $destination
+            $destination,
         ));
         $urlResponse = $this->gateway->get($origin->downloadUrl(), $destination);
         return $origin->withLastModified($urlResponse->lastModified());

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -15,7 +15,7 @@ class UrlResponse
     public function __construct(
         private readonly string $url,
         private readonly int $httpStatus,
-        DateTimeImmutable $lastModified = null,
+        DateTimeImmutable|null $lastModified = null,
         private readonly Stringable|string $body = '',
     ) {
         $this->lastModified = ($lastModified) ?: new DateTimeImmutable();

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -16,7 +16,7 @@ class UrlResponse
         private readonly string $url,
         private readonly int $httpStatus,
         DateTimeImmutable $lastModified = null,
-        private readonly Stringable|string $body = ''
+        private readonly Stringable|string $body = '',
     ) {
         $this->lastModified = ($lastModified) ?: new DateTimeImmutable();
     }

--- a/src/Origins/WebResourcesGateway.php
+++ b/src/Origins/WebResourcesGateway.php
@@ -52,7 +52,7 @@ class WebResourcesGateway implements ResourcesGatewayInterface
     public function get(string $url, string $destination): UrlResponse
     {
         $response = $this->obtainResponse('GET', $url);
-        if (200 === $response->getStatusCode() && ! empty($destination)) {
+        if (200 === $response->getStatusCode() && '' !== $destination) {
             file_put_contents($destination, $response->getBody());
         }
 

--- a/src/Origins/WebResourcesGateway.php
+++ b/src/Origins/WebResourcesGateway.php
@@ -15,7 +15,7 @@ class WebResourcesGateway implements ResourcesGatewayInterface
 {
     private readonly GuzzleClient $client;
 
-    public function __construct(GuzzleClient $client = null)
+    public function __construct(GuzzleClient|null $client = null)
     {
         $this->client = $client ?? new GuzzleClient();
     }

--- a/src/Utils/ArrayProcessors/AbstractPipeArrayProcessor.php
+++ b/src/Utils/ArrayProcessors/AbstractPipeArrayProcessor.php
@@ -8,7 +8,7 @@ abstract class AbstractPipeArrayProcessor implements ArrayProcessorInterface
 {
     private readonly ArrayProcessorInterface $next;
 
-    public function __construct(ArrayProcessorInterface $next = null)
+    public function __construct(ArrayProcessorInterface|null $next = null)
     {
         $this->next = $next ?? new NullArrayProcessor();
     }

--- a/src/Utils/ArrayProcessors/IgnoreColumns.php
+++ b/src/Utils/ArrayProcessors/IgnoreColumns.php
@@ -28,8 +28,8 @@ class IgnoreColumns extends AbstractPipeArrayProcessor implements ArrayProcessor
             array_filter(
                 $array,
                 fn (int $key): bool => ! in_array($key, $this->columns, true),
-                ARRAY_FILTER_USE_KEY
-            )
+                ARRAY_FILTER_USE_KEY,
+            ),
         );
         return parent::execute($array);
     }

--- a/src/Utils/ArrayProcessors/IgnoreColumns.php
+++ b/src/Utils/ArrayProcessors/IgnoreColumns.php
@@ -9,7 +9,7 @@ class IgnoreColumns extends AbstractPipeArrayProcessor implements ArrayProcessor
     /** @var array<int, int> */
     private readonly array $columns;
 
-    public function __construct(ArrayProcessorInterface $next = null, int ...$columns)
+    public function __construct(ArrayProcessorInterface|null $next = null, int ...$columns)
     {
         parent::__construct($next);
         $this->columns = array_values($columns);

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -107,9 +107,9 @@ class CsvFile implements SeekableIterator
             return [];
         }
         $contents = $this->file->current();
-        $contents = (! is_string($contents)) ? '' : $contents;
+        $contents = (is_string($contents)) ? $contents : '';
         $values = array_map(
-            static fn ($value) => (is_scalar($value)) ? $value : '',
+            static fn ($value): string => (is_scalar($value)) ? $value : '',
             str_getcsv($contents, escape: '\\'),
         );
         return $this->rowProcessor->execute($values);

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -110,7 +110,7 @@ class CsvFile implements SeekableIterator
         $contents = (! is_string($contents)) ? '' : $contents;
         $values = array_map(
             fn ($value) => (is_scalar($value)) ? $value : '',
-            str_getcsv($contents)
+            str_getcsv($contents),
         );
         return $this->rowProcessor->execute($values);
     }

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -21,7 +21,7 @@ class CsvFile implements SeekableIterator
 
     private readonly ArrayProcessorInterface $rowProcessor;
 
-    public function __construct(string $filename, ArrayProcessorInterface $rowProcessor = null)
+    public function __construct(string $filename, ArrayProcessorInterface|null $rowProcessor = null)
     {
         if ('' === $filename) {
             throw new UnexpectedValueException('The filename cannot be empty');
@@ -109,8 +109,8 @@ class CsvFile implements SeekableIterator
         $contents = $this->file->current();
         $contents = (! is_string($contents)) ? '' : $contents;
         $values = array_map(
-            fn ($value) => (is_scalar($value)) ? $value : '',
-            str_getcsv($contents),
+            static fn ($value) => (is_scalar($value)) ? $value : '',
+            str_getcsv($contents, escape: '\\'),
         );
         return $this->rowProcessor->execute($values);
     }

--- a/src/Utils/ShellExec.php
+++ b/src/Utils/ShellExec.php
@@ -11,7 +11,7 @@ class ShellExec
         private readonly string $command,
         private array $output = [],
         private int $exitStatus = -1,
-        private string $lastLine = ''
+        private string $lastLine = '',
     ) {
     }
 

--- a/tests/Features/Converters/XlsToCsvFolderConverterTest.php
+++ b/tests/Features/Converters/XlsToCsvFolderConverterTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
 use function PhpCfdi\SatCatalogosPopulate\Utils\tempdir;
 
-class XlsToCsvFolderConverterTest extends TestCase
+final class XlsToCsvFolderConverterTest extends TestCase
 {
     public function testConvertWithSampleFiles(): void
     {

--- a/tests/Features/Converters/XlsxToCsvFolderConverterTest.php
+++ b/tests/Features/Converters/XlsxToCsvFolderConverterTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
 use function PhpCfdi\SatCatalogosPopulate\Utils\tempdir;
 
-class XlsxToCsvFolderConverterTest extends TestCase
+final class XlsxToCsvFolderConverterTest extends TestCase
 {
     public function testConvertWithSampleFiles(): void
     {

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 
-class ImportTest extends TestCase
+final class ImportTest extends TestCase
 {
     public function testImportCfdi(): void
     {

--- a/tests/Features/Importers/Cfdi/Injectors/TiposComprobantes/ImportTiposComprobantesTest.php
+++ b/tests/Features/Importers/Cfdi/Injectors/TiposComprobantes/ImportTiposComprobantesTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\TiposComprobantes;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use Psr\Log\NullLogger;
 
-class ImportTiposComprobantesTest extends TestCase
+final class ImportTiposComprobantesTest extends TestCase
 {
     private Repository $repository;
 

--- a/tests/Features/Importers/SourcesImporterTest.php
+++ b/tests/Features/Importers/SourcesImporterTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\SourcesImporter;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use Psr\Log\NullLogger;
 
-class SourcesImporterTest extends TestCase
+final class SourcesImporterTest extends TestCase
 {
     public function testImportSourcesFromFolder(): void
     {

--- a/tests/Features/Importers/SourcesImporterTest.php
+++ b/tests/Features/Importers/SourcesImporterTest.php
@@ -148,7 +148,7 @@ class SourcesImporterTest extends TestCase
         foreach ($expectedTables as $expectedTable) {
             $this->assertTrue(
                 $repository->hasTable($expectedTable),
-                "The table $expectedTable was not found in repository"
+                "The table $expectedTable was not found in repository",
             );
             $this->assertGreaterThan(0, $repository->getRecordCount($expectedTable));
         }

--- a/tests/Features/InjectorsTest.php
+++ b/tests/Features/InjectorsTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\SatCatalogosPopulate\Injectors;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use Psr\Log\NullLogger;
 
-class InjectorsTest extends TestCase
+final class InjectorsTest extends TestCase
 {
     public function testInjectorCanInjectAWellKnownSourceFile(): void
     {

--- a/tests/Features/Origins/ConstantReviewerTest.php
+++ b/tests/Features/Origins/ConstantReviewerTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\UrlResponse;
 use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Origins\FakeGateway;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class ConstantReviewerTest extends TestCase
+final class ConstantReviewerTest extends TestCase
 {
     private ConstantReviewer $reviewer;
 

--- a/tests/Features/Origins/ConstantReviewerTest.php
+++ b/tests/Features/Origins/ConstantReviewerTest.php
@@ -26,7 +26,7 @@ class ConstantReviewerTest extends TestCase
     public function testReviewOriginWithUptodateResponse(): void
     {
         $this->resourcesGateway->add(
-            new UrlResponse('http://example.com/foo.txt', 200, new DateTimeImmutable('2017-01-02'))
+            new UrlResponse('http://example.com/foo.txt', 200, new DateTimeImmutable('2017-01-02')),
         );
         $origin = new ConstantOrigin('Foo', 'http://example.com/foo.txt', new DateTimeImmutable('2017-01-02'));
 
@@ -39,7 +39,7 @@ class ConstantReviewerTest extends TestCase
     public function testReviewOriginWithNotUpdatedResponse(): void
     {
         $this->resourcesGateway->add(
-            new UrlResponse('http://example.com/foo.txt', 200, new DateTimeImmutable('2017-01-02'))
+            new UrlResponse('http://example.com/foo.txt', 200, new DateTimeImmutable('2017-01-02')),
         );
         $origin = new ConstantOrigin('Foo', 'http://example.com/foo.txt', new DateTimeImmutable('2017-01-01'));
 

--- a/tests/Features/Origins/OriginsReaderTest.php
+++ b/tests/Features/Origins/OriginsReaderTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\OriginsIO;
 use PhpCfdi\SatCatalogosPopulate\Origins\OriginsTranslator;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class OriginsReaderTest extends TestCase
+final class OriginsReaderTest extends TestCase
 {
     public function testReadOriginsFromFile(): void
     {

--- a/tests/Features/Origins/OriginsReaderTest.php
+++ b/tests/Features/Origins/OriginsReaderTest.php
@@ -22,7 +22,7 @@ class OriginsReaderTest extends TestCase
         $translator = new OriginsTranslator();
         $originsData = array_map(
             fn (OriginInterface $origin): array => $translator->originToArray($origin),
-            $origins->all()
+            $origins->all(),
         );
 
         $expectedOrigins = [

--- a/tests/Features/Origins/ReviewersTest.php
+++ b/tests/Features/Origins/ReviewersTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
 use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Origins\FakeGateway;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class ReviewersTest extends TestCase
+final class ReviewersTest extends TestCase
 {
     private Reviewers $reviewers;
 

--- a/tests/Features/Origins/ScrapingReviewerTest.php
+++ b/tests/Features/Origins/ScrapingReviewerTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use RuntimeException;
 
-class ScrapingReviewerTest extends TestCase
+final class ScrapingReviewerTest extends TestCase
 {
     private ScrapingReviewer $reviewer;
 

--- a/tests/Features/Origins/ScrapingReviewerTest.php
+++ b/tests/Features/Origins/ScrapingReviewerTest.php
@@ -37,10 +37,10 @@ class ScrapingReviewerTest extends TestCase
         $this->urlFooFile = 'http://example.com/files/foo.txt';
         $this->urlPageToScrap = 'http://example.com/index.html';
         $fakeGateway->add( // web page to scrap
-            new UrlResponse($this->urlPageToScrap, 200, new DateTimeImmutable('2021-01-02'), $webpage)
+            new UrlResponse($this->urlPageToScrap, 200, new DateTimeImmutable('2021-01-02'), $webpage),
         );
         $fakeGateway->add( // foo file to download
-            new UrlResponse($this->urlFooFile, 200, new DateTimeImmutable('2021-01-05'), '')
+            new UrlResponse($this->urlFooFile, 200, new DateTimeImmutable('2021-01-05'), ''),
         );
     }
 
@@ -61,7 +61,7 @@ class ScrapingReviewerTest extends TestCase
         $this->assertSame(
             $this->urlFooFile,
             $reviewedOrigin->downloadUrl(),
-            'The reviewed origin should be expected url'
+            'The reviewed origin should be expected url',
         );
     }
 

--- a/tests/Features/Origins/UpgraderTest.php
+++ b/tests/Features/Origins/UpgraderTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Origins\FakeGateway;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use Psr\Log\NullLogger;
 
-class UpgraderTest extends TestCase
+final class UpgraderTest extends TestCase
 {
     private Upgrader $upgrader;
 
@@ -50,8 +50,8 @@ class UpgraderTest extends TestCase
 
         $newOrigin = $this->upgrader->upgradeReview($review);
 
-        $this->assertEquals($newOrigin->name(), $origin->name());
-        $this->assertEquals($newOrigin->url(), $origin->url());
+        $this->assertSame($newOrigin->name(), $origin->name());
+        $this->assertSame($newOrigin->url(), $origin->url());
         $this->assertEquals($newOrigin->lastVersion(), $this->lastModified);
     }
 

--- a/tests/Features/Origins/UpgraderTest.php
+++ b/tests/Features/Origins/UpgraderTest.php
@@ -88,7 +88,7 @@ class UpgraderTest extends TestCase
             $this->assertEquals(
                 $this->lastModified,
                 $origin->lastVersion(),
-                "The origin {$origin->name()} did not has the last version date"
+                "The origin {$origin->name()} did not has the last version date",
             );
         }
     }

--- a/tests/Unit/AbstractCsvInjectorTest.php
+++ b/tests/Unit/AbstractCsvInjectorTest.php
@@ -34,7 +34,7 @@ class AbstractCsvInjectorTest extends TestCase
     {
         $injector = new FakeCsvInjector(__FILE__);
         $injector->validate();
-        $this->assertTrue(true, 'The validate method did not create any exception');
+        $this->assertTrue(true, 'The validate method did not create any exception'); /** @phpstan-ignore-line */
     }
 
     /** @return array<string, array{string}> */
@@ -80,7 +80,7 @@ class AbstractCsvInjectorTest extends TestCase
         $this->assertSame(
             array_replace_recursive($retrieved, $expected),
             $retrieved,
-            'All expected elements are in the injected data'
+            'All expected elements are in the injected data',
         );
         $this->assertSame($expected[0], current($retrieved), 'The first element did match');
         $this->assertSame($expected[5], end($retrieved), 'The last element did match');

--- a/tests/Unit/AbstractCsvInjectorTest.php
+++ b/tests/Unit/AbstractCsvInjectorTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
-class AbstractCsvInjectorTest extends TestCase
+final class AbstractCsvInjectorTest extends TestCase
 {
     public function testCreateFakeCsvInjector(): void
     {
@@ -27,7 +27,7 @@ class AbstractCsvInjectorTest extends TestCase
         $sourceFile = $this->utilFilePath('sample.csv');
         $injector = new FakeCsvInjector($sourceFile);
 
-        $this->assertEquals($sourceFile, $injector->sourceFile());
+        $this->assertSame($sourceFile, $injector->sourceFile());
     }
 
     public function testValidateWithValidSourcefile(): void

--- a/tests/Unit/AbstractXlsOneSheetImporterTest.php
+++ b/tests/Unit/AbstractXlsOneSheetImporterTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\FakeXlsOneSheetImporter;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use Psr\Log\NullLogger;
 
-class AbstractXlsOneSheetImporterTest extends TestCase
+final class AbstractXlsOneSheetImporterTest extends TestCase
 {
     public function testImplementation(): void
     {

--- a/tests/Unit/Converters/CsvFolderJoinFilesTest.php
+++ b/tests/Unit/Converters/CsvFolderJoinFilesTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 
 use function PhpCfdi\SatCatalogosPopulate\Utils\tempname;
 
-class CsvFolderJoinFilesTest extends TestCase
+final class CsvFolderJoinFilesTest extends TestCase
 {
     public function testObtainFilesThatAreSplitted(): void
     {

--- a/tests/Unit/Converters/CsvFolderJoinFilesTest.php
+++ b/tests/Unit/Converters/CsvFolderJoinFilesTest.php
@@ -129,7 +129,7 @@ class CsvFolderJoinFilesTest extends TestCase
         $expectedFile = $this->utilFilePath('splitted/ExpectedFoo.csv');
 
         $files = $joiner->obtainFilesThatAreSplitted($csvFolder);
-        $fooFiles = $files[$csvFolder . '/Foo.csv'];
+        $fooFiles = $files[$csvFolder . '/Foo.csv'] ?? null;
         if (! is_array($fooFiles)) {
             $this->fail('Unexpected response from method obtainFilesThatAreSplitted');
         }

--- a/tests/Unit/Database/DataFieldsTest.php
+++ b/tests/Unit/Database/DataFieldsTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 use stdClass;
 use UnexpectedValueException;
 
-class DataFieldsTest extends TestCase
+final class DataFieldsTest extends TestCase
 {
     public function testCreateObjectWithAnArrayOfDataFields(): void
     {

--- a/tests/Unit/Database/DataTableGatewayTest.php
+++ b/tests/Unit/Database/DataTableGatewayTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\SatCatalogosPopulate\Database\Repository;
 use PhpCfdi\SatCatalogosPopulate\Database\TextDataField;
 use PHPUnit\Framework\TestCase;
 
-class DataTableGatewayTest extends TestCase
+final class DataTableGatewayTest extends TestCase
 {
     protected Repository $repository;
 
@@ -58,7 +58,7 @@ class DataTableGatewayTest extends TestCase
 
         $sql = 'select * from records where (id = :id);';
         $retrieved = $this->repository->queryRow($sql, ['id' => 'X5']);
-        $this->assertEquals(['id' => 'X5', 'description' => 'This is bar 5'], $retrieved);
+        $this->assertSame(['id' => 'X5', 'description' => 'This is bar 5'], $retrieved);
     }
 
     public function testPrimaryKeyIsHonored(): void

--- a/tests/Unit/Database/DataTableTest.php
+++ b/tests/Unit/Database/DataTableTest.php
@@ -10,7 +10,7 @@ use PhpCfdi\SatCatalogosPopulate\Database\DataTable;
 use PhpCfdi\SatCatalogosPopulate\Database\TextDataField;
 use PHPUnit\Framework\TestCase;
 
-class DataTableTest extends TestCase
+final class DataTableTest extends TestCase
 {
     public function testDataTableRequiereNotEmptyDataFields(): void
     {

--- a/tests/Unit/Database/DateDataFieldTest.php
+++ b/tests/Unit/Database/DateDataFieldTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\SatCatalogosPopulate\Database\DateDataField;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-class DateDataFieldTest extends TestCase
+final class DateDataFieldTest extends TestCase
 {
     public function testTransformWithInvalidFormatThrowsException(): void
     {

--- a/tests/Unit/Database/TextDataFieldTest.php
+++ b/tests/Unit/Database/TextDataFieldTest.php
@@ -8,7 +8,7 @@ use PhpCfdi\SatCatalogosPopulate\Database\TextDataField;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-class TextDataFieldTest extends TestCase
+final class TextDataFieldTest extends TestCase
 {
     /** @return array<string, array{string, string}> */
     public static function providerTransformPerformTrim(): array

--- a/tests/Unit/Importers/Cce/CceClavePedimentoTest.php
+++ b/tests/Unit/Importers/Cce/CceClavePedimentoTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceClavePedimento;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\ClavesPedimentos;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceClavePedimentoTest extends TestCase
+final class CceClavePedimentoTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceColoniaTest.php
+++ b/tests/Unit/Importers/Cce/CceColoniaTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceColonia;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Colonias;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceColoniaTest extends TestCase
+final class CceColoniaTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceEstadoTest.php
+++ b/tests/Unit/Importers/Cce/CceEstadoTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceEstado;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Estados;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceEstadoTest extends TestCase
+final class CceEstadoTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceFraccionArancelariaTest.php
+++ b/tests/Unit/Importers/Cce/CceFraccionArancelariaTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceFraccionArancelaria;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\FraccionesArancelarias;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceFraccionArancelariaTest extends TestCase
+final class CceFraccionArancelariaTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceIncotermTest.php
+++ b/tests/Unit/Importers/Cce/CceIncotermTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceIncoterm;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Incoterms;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceIncotermTest extends TestCase
+final class CceIncotermTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceLocalidadTest.php
+++ b/tests/Unit/Importers/Cce/CceLocalidadTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceLocalidad;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Localidades;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceLocalidadTest extends TestCase
+final class CceLocalidadTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceMotivoTrasladoTest.php
+++ b/tests/Unit/Importers/Cce/CceMotivoTrasladoTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceMotivoTraslado;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\MotivosTraslado;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceMotivoTrasladoTest extends TestCase
+final class CceMotivoTrasladoTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceMunicipioTest.php
+++ b/tests/Unit/Importers/Cce/CceMunicipioTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceMunicipio;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\Municipios;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceMunicipioTest extends TestCase
+final class CceMunicipioTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceTipoOperacionTest.php
+++ b/tests/Unit/Importers/Cce/CceTipoOperacionTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceTipoOperacion;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\TiposOperacion;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceTipoOperacionTest extends TestCase
+final class CceTipoOperacionTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/CceUnidadAduanaTest.php
+++ b/tests/Unit/Importers/Cce/CceUnidadAduanaTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceUnidadAduana;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\Injectors\UnidadesAduana;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceUnidadAduanaTest extends TestCase
+final class CceUnidadAduanaTest extends TestCase
 {
     public function testImporterInstance(): void
     {

--- a/tests/Unit/Importers/Cce/Injectors/ClavesPedimentosTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/ClavesPedimentosTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesPedimentosTest extends TestCase
+final class ClavesPedimentosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/ColoniasTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ColoniasTest extends TestCase
+final class ColoniasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/EstadosTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/EstadosTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EstadosTest extends TestCase
+final class EstadosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/FraccionesArancelariasTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/FraccionesArancelariasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class FraccionesArancelariasTest extends TestCase
+final class FraccionesArancelariasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/IncotermsTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/IncotermsTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class IncotermsTest extends TestCase
+final class IncotermsTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/LocalidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class LocalidadesTest extends TestCase
+final class LocalidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/MotivosTrasladoTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/MotivosTrasladoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MotivosTrasladoTest extends TestCase
+final class MotivosTrasladoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/MunicipiosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MunicipiosTest extends TestCase
+final class MunicipiosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/TiposOperacionTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/TiposOperacionTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposOperacionTest extends TestCase
+final class TiposOperacionTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce/Injectors/UnidadesAduanaTest.php
+++ b/tests/Unit/Importers/Cce/Injectors/UnidadesAduanaTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class UnidadesAduanaTest extends TestCase
+final class UnidadesAduanaTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cce20CatalogsTest.php
+++ b/tests/Unit/Importers/Cce20CatalogsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
+use PhpCfdi\SatCatalogosPopulate\ImporterInterface;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce20\CceClavePedimento;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce20\CceColonia;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce20\CceEstado;
@@ -17,7 +18,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce20\CceUnidadAduana;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce20Catalogs;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class Cce20CatalogsTest extends TestCase
+final class Cce20CatalogsTest extends TestCase
 {
     /**
      * @see Cce20Catalogs::createImporters()
@@ -40,7 +41,7 @@ class Cce20CatalogsTest extends TestCase
         $importer = new Cce20Catalogs();
         $importers = array_values($importer->createImporters());
 
-        $importersClasses = array_map(fn ($item) => $item::class, $importers);
+        $importersClasses = array_map(fn (ImporterInterface $item): string => $item::class, $importers);
 
         $this->assertEquals(array_replace_recursive($importersClasses, $expectedInjectorsClasses), $importersClasses);
         $this->assertCount(count($expectedInjectorsClasses), $importersClasses);

--- a/tests/Unit/Importers/CceCatalogsTest.php
+++ b/tests/Unit/Importers/CceCatalogsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
+use PhpCfdi\SatCatalogosPopulate\ImporterInterface;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceClavePedimento;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceColonia;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceEstado;
@@ -17,7 +18,7 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cce\CceUnidadAduana;
 use PhpCfdi\SatCatalogosPopulate\Importers\CceCatalogs;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CceCatalogsTest extends TestCase
+final class CceCatalogsTest extends TestCase
 {
     /**
      * @see CceCatalogs::createImporters()
@@ -42,7 +43,7 @@ class CceCatalogsTest extends TestCase
         $importer = new CceCatalogs();
         $importers = array_values($importer->createImporters());
 
-        $importersClasses = array_map(fn ($item) => $item::class, $importers);
+        $importersClasses = array_map(fn (ImporterInterface $item): string => $item::class, $importers);
 
         $this->assertEquals(array_replace_recursive($importersClasses, $expectedInjectorsClasses), $importersClasses);
         $this->assertCount(count($expectedInjectorsClasses), $importersClasses);

--- a/tests/Unit/Importers/Ccp20/Injectors/AutorizacionesNavieroTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/AutorizacionesNavieroTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class AutorizacionesNavieroTest extends TestCase
+final class AutorizacionesNavieroTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ClavesUnidadesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesUnidadesTest extends TestCase
+final class ClavesUnidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/CodigosTransporteAereoTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/CodigosTransporteAereoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class CodigosTransporteAereoTest extends TestCase
+final class CodigosTransporteAereoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ColoniasTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ColoniasTest extends TestCase
+final class ColoniasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ConfiguracionesAutotransporteTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ConfiguracionesAutotransporteTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ConfiguracionesAutotransporteTest extends TestCase
+final class ConfiguracionesAutotransporteTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ConfiguracionesMaritimasTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ConfiguracionesMaritimasTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ConfiguracionesMaritimasTest extends TestCase
+final class ConfiguracionesMaritimasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ContenedoresMaritimosTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ContenedoresMaritimosTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ContenedoresMaritimosTest extends TestCase
+final class ContenedoresMaritimosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ContenedoresTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ContenedoresTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ContenedoresTest extends TestCase
+final class ContenedoresTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/DerechosDePasoTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/DerechosDePasoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class DerechosDePasoTest extends TestCase
+final class DerechosDePasoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/EstacionesTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/EstacionesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EstacionesTest extends TestCase
+final class EstacionesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/FigurasTransporteTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/FigurasTransporteTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class FigurasTransporteTest extends TestCase
+final class FigurasTransporteTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/LocalidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class LocalidadesTest extends TestCase
+final class LocalidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/MaterialesPeligrososTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/MaterialesPeligrososTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MaterialesPeligrososTest extends TestCase
+final class MaterialesPeligrososTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/MunicipiosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MunicipiosTest extends TestCase
+final class MunicipiosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/PartesTransporteTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/PartesTransporteTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PartesTransporteTest extends TestCase
+final class PartesTransporteTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/ProductosServiciosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ProductosServiciosTest extends TestCase
+final class ProductosServiciosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposCargaTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposCargaTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposCargaTest extends TestCase
+final class TiposCargaTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposCarroTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposCarroTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposCarroTest extends TestCase
+final class TiposCarroTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposEmbalajeTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposEmbalajeTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposEmbalajeTest extends TestCase
+final class TiposEmbalajeTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposEstacionTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposEstacionTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposEstacionTest extends TestCase
+final class TiposEstacionTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposPermisoTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposPermisoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposPermisoTest extends TestCase
+final class TiposPermisoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposRemolqueTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposRemolqueTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposRemolqueTest extends TestCase
+final class TiposRemolqueTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposServicioTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposServicioTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposServicioTest extends TestCase
+final class TiposServicioTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TiposTraficoTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TiposTraficoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposTraficoTest extends TestCase
+final class TiposTraficoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20/Injectors/TransportesTest.php
+++ b/tests/Unit/Importers/Ccp20/Injectors/TransportesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TransportesTest extends TestCase
+final class TransportesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ccp20CatalogsTest.php
+++ b/tests/Unit/Importers/Ccp20CatalogsTest.php
@@ -6,9 +6,10 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp20\Injectors;
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp20Catalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class Ccp20CatalogsTest extends TestCase
+final class Ccp20CatalogsTest extends TestCase
 {
     /**
      * @see Ccp20Catalogs::createInjectors()
@@ -46,7 +47,7 @@ class Ccp20CatalogsTest extends TestCase
         $importer = new Ccp20Catalogs();
         $ccpInjectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $ccpInjectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $ccpInjectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/Ccp30/Injectors/AutorizacionesNavieroTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/AutorizacionesNavieroTest.php
@@ -63,7 +63,7 @@ class AutorizacionesNavieroTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/AutorizacionesNavieroTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/AutorizacionesNavieroTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class AutorizacionesNavieroTest extends TestCase
+final class AutorizacionesNavieroTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ClavesUnidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesUnidadesTest extends TestCase
+final class ClavesUnidadesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ClavesUnidadesTest.php
@@ -68,7 +68,7 @@ class ClavesUnidadesTest extends TestCase
                 'simbolo' => TextDataField::class,
                 'bandera' => TextDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/CodigosTransporteAereoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/CodigosTransporteAereoTest.php
@@ -66,7 +66,7 @@ class CodigosTransporteAereoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/CodigosTransporteAereoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/CodigosTransporteAereoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class CodigosTransporteAereoTest extends TestCase
+final class CodigosTransporteAereoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ColoniasTest.php
@@ -63,7 +63,7 @@ class ColoniasTest extends TestCase
                 'codigo_postal' => PaddingDataField::class,
                 'texto' => TextDataField::class,
             ],
-            ['colonia', 'codigo_postal']
+            ['colonia', 'codigo_postal'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ColoniasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ColoniasTest extends TestCase
+final class ColoniasTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/CondicionesEspecialesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/CondicionesEspecialesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class CondicionesEspecialesTest extends TestCase
+final class CondicionesEspecialesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/CondicionesEspecialesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/CondicionesEspecialesTest.php
@@ -65,7 +65,7 @@ class CondicionesEspecialesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesAutotransporteTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesAutotransporteTest.php
@@ -68,7 +68,7 @@ class ConfiguracionesAutotransporteTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesAutotransporteTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesAutotransporteTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ConfiguracionesAutotransporteTest extends TestCase
+final class ConfiguracionesAutotransporteTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesMaritimasTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesMaritimasTest.php
@@ -64,7 +64,7 @@ class ConfiguracionesMaritimasTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesMaritimasTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ConfiguracionesMaritimasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ConfiguracionesMaritimasTest extends TestCase
+final class ConfiguracionesMaritimasTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ContenedoresMaritimosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ContenedoresMaritimosTest.php
@@ -64,7 +64,7 @@ class ContenedoresMaritimosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ContenedoresMaritimosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ContenedoresMaritimosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ContenedoresMaritimosTest extends TestCase
+final class ContenedoresMaritimosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ContenedoresTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ContenedoresTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ContenedoresTest extends TestCase
+final class ContenedoresTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/ContenedoresTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ContenedoresTest.php
@@ -65,7 +65,7 @@ class ContenedoresTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/DerechosDePasoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/DerechosDePasoTest.php
@@ -68,7 +68,7 @@ class DerechosDePasoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/DerechosDePasoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/DerechosDePasoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class DerechosDePasoTest extends TestCase
+final class DerechosDePasoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/DocumentosAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/DocumentosAduanerosTest.php
@@ -65,7 +65,7 @@ class DocumentosAduanerosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/DocumentosAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/DocumentosAduanerosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class DocumentosAduanerosTest extends TestCase
+final class DocumentosAduanerosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/EstacionesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/EstacionesTest.php
@@ -68,7 +68,7 @@ class EstacionesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/EstacionesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/EstacionesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EstacionesTest extends TestCase
+final class EstacionesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/FigurasTransporteTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/FigurasTransporteTest.php
@@ -65,7 +65,7 @@ class FigurasTransporteTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/FigurasTransporteTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/FigurasTransporteTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class FigurasTransporteTest extends TestCase
+final class FigurasTransporteTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/FormasFarmaceuticasTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/FormasFarmaceuticasTest.php
@@ -65,7 +65,7 @@ class FormasFarmaceuticasTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/FormasFarmaceuticasTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/FormasFarmaceuticasTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class FormasFarmaceuticasTest extends TestCase
+final class FormasFarmaceuticasTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/LocalidadesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class LocalidadesTest extends TestCase
+final class LocalidadesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/LocalidadesTest.php
@@ -66,7 +66,7 @@ class LocalidadesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['localidad', 'estado']
+            ['localidad', 'estado'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/MaterialesPeligrososTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/MaterialesPeligrososTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MaterialesPeligrososTest extends TestCase
+final class MaterialesPeligrososTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/MaterialesPeligrososTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/MaterialesPeligrososTest.php
@@ -68,7 +68,7 @@ class MaterialesPeligrososTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            []
+            [],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/MunicipiosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MunicipiosTest extends TestCase
+final class MunicipiosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/MunicipiosTest.php
@@ -66,7 +66,7 @@ class MunicipiosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['municipio', 'estado']
+            ['municipio', 'estado'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/PartesTransporteTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/PartesTransporteTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PartesTransporteTest extends TestCase
+final class PartesTransporteTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/PartesTransporteTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/PartesTransporteTest.php
@@ -64,7 +64,7 @@ class PartesTransporteTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ProductosServiciosTest.php
@@ -67,7 +67,7 @@ class ProductosServiciosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/ProductosServiciosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ProductosServiciosTest extends TestCase
+final class ProductosServiciosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/RegimenesAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/RegimenesAduanerosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class RegimenesAduanerosTest extends TestCase
+final class RegimenesAduanerosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/RegimenesAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/RegimenesAduanerosTest.php
@@ -65,7 +65,7 @@ class RegimenesAduanerosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/RegistrosIstmoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/RegistrosIstmoTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class RegistrosIstmoTest extends TestCase
+final class RegistrosIstmoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/RegistrosIstmoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/RegistrosIstmoTest.php
@@ -65,7 +65,7 @@ class RegistrosIstmoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/SectoresCofeprisTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/SectoresCofeprisTest.php
@@ -65,7 +65,7 @@ class SectoresCofeprisTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/SectoresCofeprisTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/SectoresCofeprisTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class SectoresCofeprisTest extends TestCase
+final class SectoresCofeprisTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposCargaTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposCargaTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposCargaTest extends TestCase
+final class TiposCargaTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposCargaTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposCargaTest.php
@@ -64,7 +64,7 @@ class TiposCargaTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposCarroTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposCarroTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposCarroTest extends TestCase
+final class TiposCarroTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposCarroTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposCarroTest.php
@@ -65,7 +65,7 @@ class TiposCarroTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposEmbalajeTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposEmbalajeTest.php
@@ -64,7 +64,7 @@ class TiposEmbalajeTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposEmbalajeTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposEmbalajeTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposEmbalajeTest extends TestCase
+final class TiposEmbalajeTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposEstacionTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposEstacionTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposEstacionTest extends TestCase
+final class TiposEstacionTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposEstacionTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposEstacionTest.php
@@ -66,7 +66,7 @@ class TiposEstacionTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposMateriaTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposMateriaTest.php
@@ -65,7 +65,7 @@ class TiposMateriaTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposMateriaTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposMateriaTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposMateriaTest extends TestCase
+final class TiposMateriaTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposPermisoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposPermisoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposPermisoTest extends TestCase
+final class TiposPermisoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposPermisoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposPermisoTest.php
@@ -65,7 +65,7 @@ class TiposPermisoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposRemolqueTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposRemolqueTest.php
@@ -64,7 +64,7 @@ class TiposRemolqueTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposRemolqueTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposRemolqueTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposRemolqueTest extends TestCase
+final class TiposRemolqueTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposServicioTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposServicioTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposServicioTest extends TestCase
+final class TiposServicioTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposServicioTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposServicioTest.php
@@ -65,7 +65,7 @@ class TiposServicioTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposTraficoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposTraficoTest.php
@@ -64,7 +64,7 @@ class TiposTraficoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30/Injectors/TiposTraficoTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TiposTraficoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposTraficoTest extends TestCase
+final class TiposTraficoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TransportesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TransportesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TransportesTest extends TestCase
+final class TransportesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp30/Injectors/TransportesTest.php
+++ b/tests/Unit/Importers/Ccp30/Injectors/TransportesTest.php
@@ -65,7 +65,7 @@ class TransportesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp30CatalogsTest.php
+++ b/tests/Unit/Importers/Ccp30CatalogsTest.php
@@ -6,9 +6,10 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp30\Injectors;
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp30Catalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class Ccp30CatalogsTest extends TestCase
+final class Ccp30CatalogsTest extends TestCase
 {
     /**
      * @see Ccp30Catalogs::createInjectors()
@@ -53,7 +54,7 @@ class Ccp30CatalogsTest extends TestCase
         $importer = new Ccp30Catalogs();
         $ccpInjectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $ccpInjectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $ccpInjectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/Ccp31/Injectors/AutorizacionesNavieroTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/AutorizacionesNavieroTest.php
@@ -63,7 +63,7 @@ class AutorizacionesNavieroTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/AutorizacionesNavieroTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/AutorizacionesNavieroTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class AutorizacionesNavieroTest extends TestCase
+final class AutorizacionesNavieroTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ClavesUnidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesUnidadesTest extends TestCase
+final class ClavesUnidadesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ClavesUnidadesTest.php
@@ -68,7 +68,7 @@ class ClavesUnidadesTest extends TestCase
                 'simbolo' => TextDataField::class,
                 'bandera' => TextDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/CodigosTransporteAereoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/CodigosTransporteAereoTest.php
@@ -66,7 +66,7 @@ class CodigosTransporteAereoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/CodigosTransporteAereoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/CodigosTransporteAereoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class CodigosTransporteAereoTest extends TestCase
+final class CodigosTransporteAereoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ColoniasTest.php
@@ -63,7 +63,7 @@ class ColoniasTest extends TestCase
                 'codigo_postal' => PaddingDataField::class,
                 'texto' => TextDataField::class,
             ],
-            ['colonia', 'codigo_postal']
+            ['colonia', 'codigo_postal'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ColoniasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ColoniasTest extends TestCase
+final class ColoniasTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/CondicionesEspecialesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/CondicionesEspecialesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class CondicionesEspecialesTest extends TestCase
+final class CondicionesEspecialesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/CondicionesEspecialesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/CondicionesEspecialesTest.php
@@ -65,7 +65,7 @@ class CondicionesEspecialesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesAutotransporteTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesAutotransporteTest.php
@@ -68,7 +68,7 @@ class ConfiguracionesAutotransporteTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesAutotransporteTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesAutotransporteTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ConfiguracionesAutotransporteTest extends TestCase
+final class ConfiguracionesAutotransporteTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesMaritimasTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesMaritimasTest.php
@@ -64,7 +64,7 @@ class ConfiguracionesMaritimasTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesMaritimasTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ConfiguracionesMaritimasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ConfiguracionesMaritimasTest extends TestCase
+final class ConfiguracionesMaritimasTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ContenedoresMaritimosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ContenedoresMaritimosTest.php
@@ -64,7 +64,7 @@ class ContenedoresMaritimosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ContenedoresMaritimosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ContenedoresMaritimosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ContenedoresMaritimosTest extends TestCase
+final class ContenedoresMaritimosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ContenedoresTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ContenedoresTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ContenedoresTest extends TestCase
+final class ContenedoresTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/ContenedoresTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ContenedoresTest.php
@@ -65,7 +65,7 @@ class ContenedoresTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/DerechosDePasoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/DerechosDePasoTest.php
@@ -68,7 +68,7 @@ class DerechosDePasoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/DerechosDePasoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/DerechosDePasoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class DerechosDePasoTest extends TestCase
+final class DerechosDePasoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/DocumentosAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/DocumentosAduanerosTest.php
@@ -65,7 +65,7 @@ class DocumentosAduanerosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/DocumentosAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/DocumentosAduanerosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class DocumentosAduanerosTest extends TestCase
+final class DocumentosAduanerosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/EstacionesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/EstacionesTest.php
@@ -68,7 +68,7 @@ class EstacionesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/EstacionesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/EstacionesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EstacionesTest extends TestCase
+final class EstacionesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/FigurasTransporteTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/FigurasTransporteTest.php
@@ -65,7 +65,7 @@ class FigurasTransporteTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/FigurasTransporteTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/FigurasTransporteTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class FigurasTransporteTest extends TestCase
+final class FigurasTransporteTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/FormasFarmaceuticasTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/FormasFarmaceuticasTest.php
@@ -65,7 +65,7 @@ class FormasFarmaceuticasTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/FormasFarmaceuticasTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/FormasFarmaceuticasTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class FormasFarmaceuticasTest extends TestCase
+final class FormasFarmaceuticasTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/LocalidadesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class LocalidadesTest extends TestCase
+final class LocalidadesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/LocalidadesTest.php
@@ -66,7 +66,7 @@ class LocalidadesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['localidad', 'estado']
+            ['localidad', 'estado'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/MaterialesPeligrososTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/MaterialesPeligrososTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MaterialesPeligrososTest extends TestCase
+final class MaterialesPeligrososTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/MaterialesPeligrososTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/MaterialesPeligrososTest.php
@@ -68,7 +68,7 @@ class MaterialesPeligrososTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            []
+            [],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/MunicipiosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MunicipiosTest extends TestCase
+final class MunicipiosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/MunicipiosTest.php
@@ -66,7 +66,7 @@ class MunicipiosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['municipio', 'estado']
+            ['municipio', 'estado'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/PartesTransporteTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/PartesTransporteTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PartesTransporteTest extends TestCase
+final class PartesTransporteTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/PartesTransporteTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/PartesTransporteTest.php
@@ -64,7 +64,7 @@ class PartesTransporteTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ProductosServiciosTest.php
@@ -67,7 +67,7 @@ class ProductosServiciosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/ProductosServiciosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ProductosServiciosTest extends TestCase
+final class ProductosServiciosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/RegimenesAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/RegimenesAduanerosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class RegimenesAduanerosTest extends TestCase
+final class RegimenesAduanerosTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/RegimenesAduanerosTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/RegimenesAduanerosTest.php
@@ -65,7 +65,7 @@ class RegimenesAduanerosTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/RegistrosIstmoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/RegistrosIstmoTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class RegistrosIstmoTest extends TestCase
+final class RegistrosIstmoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/RegistrosIstmoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/RegistrosIstmoTest.php
@@ -65,7 +65,7 @@ class RegistrosIstmoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/SectoresCofeprisTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/SectoresCofeprisTest.php
@@ -65,7 +65,7 @@ class SectoresCofeprisTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/SectoresCofeprisTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/SectoresCofeprisTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class SectoresCofeprisTest extends TestCase
+final class SectoresCofeprisTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposCargaTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposCargaTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposCargaTest extends TestCase
+final class TiposCargaTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposCargaTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposCargaTest.php
@@ -64,7 +64,7 @@ class TiposCargaTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposCarroTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposCarroTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposCarroTest extends TestCase
+final class TiposCarroTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposCarroTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposCarroTest.php
@@ -65,7 +65,7 @@ class TiposCarroTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposEmbalajeTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposEmbalajeTest.php
@@ -64,7 +64,7 @@ class TiposEmbalajeTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposEmbalajeTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposEmbalajeTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposEmbalajeTest extends TestCase
+final class TiposEmbalajeTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposEstacionTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposEstacionTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposEstacionTest extends TestCase
+final class TiposEstacionTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposEstacionTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposEstacionTest.php
@@ -66,7 +66,7 @@ class TiposEstacionTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposMateriaTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposMateriaTest.php
@@ -65,7 +65,7 @@ class TiposMateriaTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposMateriaTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposMateriaTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposMateriaTest extends TestCase
+final class TiposMateriaTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposPermisoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposPermisoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposPermisoTest extends TestCase
+final class TiposPermisoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposPermisoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposPermisoTest.php
@@ -65,7 +65,7 @@ class TiposPermisoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposRemolqueTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposRemolqueTest.php
@@ -64,7 +64,7 @@ class TiposRemolqueTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposRemolqueTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposRemolqueTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposRemolqueTest extends TestCase
+final class TiposRemolqueTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposServicioTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposServicioTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposServicioTest extends TestCase
+final class TiposServicioTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposServicioTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposServicioTest.php
@@ -65,7 +65,7 @@ class TiposServicioTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposTraficoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposTraficoTest.php
@@ -64,7 +64,7 @@ class TiposTraficoTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31/Injectors/TiposTraficoTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TiposTraficoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposTraficoTest extends TestCase
+final class TiposTraficoTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TransportesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TransportesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TransportesTest extends TestCase
+final class TransportesTest extends TestCase
 {
     use CheckDataTableTrait;
 

--- a/tests/Unit/Importers/Ccp31/Injectors/TransportesTest.php
+++ b/tests/Unit/Importers/Ccp31/Injectors/TransportesTest.php
@@ -65,7 +65,7 @@ class TransportesTest extends TestCase
                 'vigencia_desde' => DateDataField::class,
                 'vigencia_hasta' => DateDataField::class,
             ],
-            ['id']
+            ['id'],
         );
     }
 }

--- a/tests/Unit/Importers/Ccp31CatalogsTest.php
+++ b/tests/Unit/Importers/Ccp31CatalogsTest.php
@@ -6,9 +6,10 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp31\Injectors;
 use PhpCfdi\SatCatalogosPopulate\Importers\Ccp31Catalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class Ccp31CatalogsTest extends TestCase
+final class Ccp31CatalogsTest extends TestCase
 {
     /**
      * @see Ccp31Catalogs::createInjectors()
@@ -53,7 +54,7 @@ class Ccp31CatalogsTest extends TestCase
         $importer = new Ccp31Catalogs();
         $ccpInjectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $ccpInjectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $ccpInjectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/Cfdi/Injectors/AduanasTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/AduanasTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class AduanasTest extends TestCase
+final class AduanasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/AduanasTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/AduanasTest.php
@@ -54,7 +54,7 @@ class AduanasTest extends TestCase
         $this->assertSame('cfdi_aduanas', $dataTable->name());
         $this->assertSame(
             ['id', 'texto', 'vigencia_desde', 'vigencia_hasta'],
-            $dataTable->fields()->keys()
+            $dataTable->fields()->keys(),
         );
     }
 }

--- a/tests/Unit/Importers/Cfdi/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/ClavesUnidadesTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesUnidadesTest extends TestCase
+final class ClavesUnidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/CodigosPostalesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/CodigosPostalesTest.php
@@ -117,7 +117,7 @@ class CodigosPostalesTest extends TestCase
         $this->assertGreaterThan(
             0,
             $count,
-            sprintf('Cannot find records with estimulo_frontera = %s', $estimuloFrontera)
+            sprintf('Cannot find records with estimulo_frontera = %s', $estimuloFrontera),
         );
     }
 }

--- a/tests/Unit/Importers/Cfdi/Injectors/CodigosPostalesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/CodigosPostalesTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
-class CodigosPostalesTest extends TestCase
+final class CodigosPostalesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/FormasDePagoTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/FormasDePagoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class FormasDePagoTest extends TestCase
+final class FormasDePagoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/ImpuestosTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/ImpuestosTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class ImpuestosTest extends TestCase
+final class ImpuestosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/MetodosDePagoTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/MetodosDePagoTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MetodosDePagoTest extends TestCase
+final class MetodosDePagoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/MonedasTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/MonedasTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MonedasTest extends TestCase
+final class MonedasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/NumerosPedimentoAduanaTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/NumerosPedimentoAduanaTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class NumerosPedimentoAduanaTest extends TestCase
+final class NumerosPedimentoAduanaTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/PaisesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/PaisesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class PaisesTest extends TestCase
+final class PaisesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/PatentesAduanalesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/PatentesAduanalesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class PatentesAduanalesTest extends TestCase
+final class PatentesAduanalesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/ProductosServiciosTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ProductosServiciosTest extends TestCase
+final class ProductosServiciosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/RegimenesFiscalesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/RegimenesFiscalesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class RegimenesFiscalesTest extends TestCase
+final class RegimenesFiscalesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/ReglasTasaCuotaTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/ReglasTasaCuotaTest.php
@@ -17,7 +17,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class ReglasTasaCuotaTest extends TestCase
+final class ReglasTasaCuotaTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/TiposComprobantesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/TiposComprobantesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposComprobantesTest extends TestCase
+final class TiposComprobantesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/TiposFactoresTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/TiposFactoresTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposFactoresTest extends TestCase
+final class TiposFactoresTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/TiposRelacionesTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/TiposRelacionesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposRelacionesTest extends TestCase
+final class TiposRelacionesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi/Injectors/UsosCfdiTest.php
+++ b/tests/Unit/Importers/Cfdi/Injectors/UsosCfdiTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class UsosCfdiTest extends TestCase
+final class UsosCfdiTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/AduanasTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/AduanasTest.php
@@ -54,7 +54,7 @@ class AduanasTest extends TestCase
         $this->assertSame('cfdi_40_aduanas', $dataTable->name());
         $this->assertSame(
             ['id', 'texto', 'vigencia_desde', 'vigencia_hasta'],
-            $dataTable->fields()->keys()
+            $dataTable->fields()->keys(),
         );
     }
 }

--- a/tests/Unit/Importers/Cfdi40/Injectors/AduanasTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/AduanasTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class AduanasTest extends TestCase
+final class AduanasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ClavesUnidadesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ClavesUnidadesTest.php
@@ -12,7 +12,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesUnidadesTest extends TestCase
+final class ClavesUnidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/CodigosPostalesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/CodigosPostalesTest.php
@@ -117,7 +117,7 @@ class CodigosPostalesTest extends TestCase
         $this->assertGreaterThan(
             0,
             $count,
-            sprintf('Cannot find records with estimulo_frontera = %s', $estimuloFrontera)
+            sprintf('Cannot find records with estimulo_frontera = %s', $estimuloFrontera),
         );
     }
 }

--- a/tests/Unit/Importers/Cfdi40/Injectors/CodigosPostalesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/CodigosPostalesTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Log\NullLogger;
 use RuntimeException;
 
-class CodigosPostalesTest extends TestCase
+final class CodigosPostalesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ColoniasTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ColoniasTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ColoniasTest extends TestCase
+final class ColoniasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/EstadosTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/EstadosTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EstadosTest extends TestCase
+final class EstadosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ExportacionesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ExportacionesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ExportacionesTest extends TestCase
+final class ExportacionesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/FormasDePagoTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/FormasDePagoTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class FormasDePagoTest extends TestCase
+final class FormasDePagoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ImpuestosTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ImpuestosTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class ImpuestosTest extends TestCase
+final class ImpuestosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/LocalidadesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/LocalidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class LocalidadesTest extends TestCase
+final class LocalidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/MesesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/MesesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MesesTest extends TestCase
+final class MesesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/MetodosDePagoTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/MetodosDePagoTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MetodosDePagoTest extends TestCase
+final class MetodosDePagoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/MonedasTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/MonedasTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MonedasTest extends TestCase
+final class MonedasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/MunicipiosTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/MunicipiosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class MunicipiosTest extends TestCase
+final class MunicipiosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/NumerosPedimentoAduanaTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/NumerosPedimentoAduanaTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class NumerosPedimentoAduanaTest extends TestCase
+final class NumerosPedimentoAduanaTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ObjetosDeImpuestoTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ObjetosDeImpuestoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ObjetosDeImpuestoTest extends TestCase
+final class ObjetosDeImpuestoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/PaisesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/PaisesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class PaisesTest extends TestCase
+final class PaisesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/PatentesAduanalesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/PatentesAduanalesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class PatentesAduanalesTest extends TestCase
+final class PatentesAduanalesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/PeriodicidadesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/PeriodicidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PeriodicidadesTest extends TestCase
+final class PeriodicidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ProductosServiciosTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ProductosServiciosTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ProductosServiciosTest extends TestCase
+final class ProductosServiciosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/RegimenesFiscalesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/RegimenesFiscalesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class RegimenesFiscalesTest extends TestCase
+final class RegimenesFiscalesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/ReglasTasaCuotaTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/ReglasTasaCuotaTest.php
@@ -17,7 +17,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class ReglasTasaCuotaTest extends TestCase
+final class ReglasTasaCuotaTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/TiposComprobantesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/TiposComprobantesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposComprobantesTest extends TestCase
+final class TiposComprobantesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/TiposFactoresTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/TiposFactoresTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposFactoresTest extends TestCase
+final class TiposFactoresTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/TiposRelacionesTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/TiposRelacionesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposRelacionesTest extends TestCase
+final class TiposRelacionesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40/Injectors/UsosCfdiTest.php
+++ b/tests/Unit/Importers/Cfdi40/Injectors/UsosCfdiTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class UsosCfdiTest extends TestCase
+final class UsosCfdiTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Cfdi40CatalogsTest.php
+++ b/tests/Unit/Importers/Cfdi40CatalogsTest.php
@@ -30,9 +30,10 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors\TiposFactores;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors\TiposRelaciones;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors\UsosCfdi;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40Catalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class Cfdi40CatalogsTest extends TestCase
+final class Cfdi40CatalogsTest extends TestCase
 {
     /**
      * @see CfdiCatalogs::createInjectors()
@@ -70,7 +71,7 @@ class Cfdi40CatalogsTest extends TestCase
         $importer = new Cfdi40Catalogs();
         $cfdiInjectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $cfdiInjectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $cfdiInjectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/CfdiCatalogsTest.php
+++ b/tests/Unit/Importers/CfdiCatalogsTest.php
@@ -22,9 +22,10 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\TiposFactores;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\TiposRelaciones;
 use PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors\UsosCfdi;
 use PhpCfdi\SatCatalogosPopulate\Importers\CfdiCatalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class CfdiCatalogsTest extends TestCase
+final class CfdiCatalogsTest extends TestCase
 {
     /**
      * @see CfdiCatalogs::createInjectors()
@@ -54,7 +55,7 @@ class CfdiCatalogsTest extends TestCase
         $importer = new CfdiCatalogs();
         $cfdiInjectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $cfdiInjectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $cfdiInjectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/CheckDataTableTrait.php
+++ b/tests/Unit/Importers/CheckDataTableTrait.php
@@ -12,7 +12,6 @@ trait CheckDataTableTrait
     /**
      * @param array<string, class-string> $expectedClasses
      * @param string[] $ids
-     * @return void
      */
     private function checkDataTable(DataTable $dataTable, string $tableName, array $expectedClasses, array $ids): void
     {

--- a/tests/Unit/Importers/CheckDataTableTrait.php
+++ b/tests/Unit/Importers/CheckDataTableTrait.php
@@ -6,7 +6,6 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Database\DataTable;
 use PhpCfdi\SatCatalogosPopulate\Database\PreprocessDataField;
-use PHPUnit\Framework\TestCase;
 
 trait CheckDataTableTrait
 {
@@ -17,9 +16,6 @@ trait CheckDataTableTrait
      */
     private function checkDataTable(DataTable $dataTable, string $tableName, array $expectedClasses, array $ids): void
     {
-        /**
-         * @var TestCase $this
-         */
         // check expected table name
         $this->assertSame($tableName, $dataTable->name());
 

--- a/tests/Unit/Importers/Nomina/Injectors/BancosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/BancosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class BancosTest extends TestCase
+final class BancosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/EstadosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/EstadosTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EstadosTest extends TestCase
+final class EstadosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/OrigenesRecursosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/OrigenesRecursosTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class OrigenesRecursosTest extends TestCase
+final class OrigenesRecursosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/PeriodicidadesPagosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/PeriodicidadesPagosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class PeriodicidadesPagosTest extends TestCase
+final class PeriodicidadesPagosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/RiesgosPuestosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/RiesgosPuestosTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class RiesgosPuestosTest extends TestCase
+final class RiesgosPuestosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposContratosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposContratosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposContratosTest extends TestCase
+final class TiposContratosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposDeduccionesTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposDeduccionesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposDeduccionesTest extends TestCase
+final class TiposDeduccionesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposHorasTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposHorasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposHorasTest extends TestCase
+final class TiposHorasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposIncapacidadesTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposIncapacidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposIncapacidadesTest extends TestCase
+final class TiposIncapacidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposJornadasTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposJornadasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposJornadasTest extends TestCase
+final class TiposJornadasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposNominasTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposNominasTest.php
@@ -13,7 +13,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposNominasTest extends TestCase
+final class TiposNominasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposOtrosPagosTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposOtrosPagosTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposOtrosPagosTest extends TestCase
+final class TiposOtrosPagosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposPercepcionesTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposPercepcionesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposPercepcionesTest extends TestCase
+final class TiposPercepcionesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Nomina/Injectors/TiposRegimenesTest.php
+++ b/tests/Unit/Importers/Nomina/Injectors/TiposRegimenesTest.php
@@ -16,7 +16,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposRegimenesTest extends TestCase
+final class TiposRegimenesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/NominaCatalogsTest.php
+++ b/tests/Unit/Importers/NominaCatalogsTest.php
@@ -18,9 +18,10 @@ use PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\TiposOtrosPagos;
 use PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\TiposPercepciones;
 use PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\TiposRegimenes;
 use PhpCfdi\SatCatalogosPopulate\Importers\NominaCatalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class NominaCatalogsTest extends TestCase
+final class NominaCatalogsTest extends TestCase
 {
     /**
      * @see NominaCatalogs::createInjectors()
@@ -46,7 +47,7 @@ class NominaCatalogsTest extends TestCase
         $importer = new NominaCatalogs();
         $injectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $injectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $injectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/NominaEstadosCatalogsTest.php
+++ b/tests/Unit/Importers/NominaEstadosCatalogsTest.php
@@ -6,9 +6,10 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Importers\Nomina\Injectors\Estados;
 use PhpCfdi\SatCatalogosPopulate\Importers\NominaEstadosCatalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class NominaEstadosCatalogsTest extends TestCase
+final class NominaEstadosCatalogsTest extends TestCase
 {
     /**
      * @see NominaCatalogs::createInjectors()
@@ -22,7 +23,7 @@ class NominaEstadosCatalogsTest extends TestCase
         $importer = new NominaEstadosCatalogs();
         $injectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $injectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $injectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/Rep/Injectors/TiposCadenaPagoTest.php
+++ b/tests/Unit/Importers/Rep/Injectors/TiposCadenaPagoTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use PHPUnit\Framework\Attributes\TestWith;
 use RuntimeException;
 
-class TiposCadenaPagoTest extends TestCase
+final class TiposCadenaPagoTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/RepCatalogsTest.php
+++ b/tests/Unit/Importers/RepCatalogsTest.php
@@ -6,9 +6,10 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Importers\Rep\Injectors\TiposCadenaPago;
 use PhpCfdi\SatCatalogosPopulate\Importers\RepCatalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class RepCatalogsTest extends TestCase
+final class RepCatalogsTest extends TestCase
 {
     /**
      * @see RepCatalogs::createInjectors()
@@ -22,7 +23,7 @@ class RepCatalogsTest extends TestCase
         $importer = new RepCatalogs();
         $injectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $injectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $injectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Importers/Ret20/Injectors/ClavesRetencionTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/ClavesRetencionTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class ClavesRetencionTest extends TestCase
+final class ClavesRetencionTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/EjerciciosTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/EjerciciosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EjerciciosTest extends TestCase
+final class EjerciciosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/EntidadesFederativasTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/EntidadesFederativasTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class EntidadesFederativasTest extends TestCase
+final class EntidadesFederativasTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/PaisesTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/PaisesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PaisesTest extends TestCase
+final class PaisesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/PeriodicidadesTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/PeriodicidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PeriodicidadesTest extends TestCase
+final class PeriodicidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/PeriodosTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/PeriodosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class PeriodosTest extends TestCase
+final class PeriodosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/TiposContribuyentesTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/TiposContribuyentesTest.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposContribuyentesTest extends TestCase
+final class TiposContribuyentesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/TiposDividendosUtilidadesTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/TiposDividendosUtilidadesTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposDividendosUtilidadesTest extends TestCase
+final class TiposDividendosUtilidadesTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/TiposImpuestosTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/TiposImpuestosTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposImpuestosTest extends TestCase
+final class TiposImpuestosTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20/Injectors/TiposPagoRetencionTest.php
+++ b/tests/Unit/Importers/Ret20/Injectors/TiposPagoRetencionTest.php
@@ -15,7 +15,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class TiposPagoRetencionTest extends TestCase
+final class TiposPagoRetencionTest extends TestCase
 {
     private string $sourceFile;
 

--- a/tests/Unit/Importers/Ret20CatalogsTest.php
+++ b/tests/Unit/Importers/Ret20CatalogsTest.php
@@ -6,9 +6,10 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Importers;
 
 use PhpCfdi\SatCatalogosPopulate\Importers\Ret20\Injectors;
 use PhpCfdi\SatCatalogosPopulate\Importers\Ret20Catalogs;
+use PhpCfdi\SatCatalogosPopulate\InjectorInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class Ret20CatalogsTest extends TestCase
+final class Ret20CatalogsTest extends TestCase
 {
     /**
      * @see Ret20Catalogs::createInjectors()
@@ -31,7 +32,7 @@ class Ret20CatalogsTest extends TestCase
         $importer = new Ret20Catalogs();
         $retInjectors = $importer->createInjectors('');
 
-        $injectorsClasses = array_map(fn ($item) => $item::class, $retInjectors->all());
+        $injectorsClasses = array_map(fn (InjectorInterface $item): string => $item::class, $retInjectors->all());
 
         $this->assertEquals(array_replace_recursive($injectorsClasses, $expectedInjectorsClasses), $injectorsClasses);
         $this->assertCount(count($expectedInjectorsClasses), $injectorsClasses);

--- a/tests/Unit/Origins/ConstantReviewerTest.php
+++ b/tests/Unit/Origins/ConstantReviewerTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class ConstantReviewerTest extends TestCase
+final class ConstantReviewerTest extends TestCase
 {
     private ConstantReviewer $reviewer;
 

--- a/tests/Unit/Origins/ScrapingReviewerTest.php
+++ b/tests/Unit/Origins/ScrapingReviewerTest.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewer;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 
-class ScrapingReviewerTest extends TestCase
+final class ScrapingReviewerTest extends TestCase
 {
     private ScrapingReviewer $reviewer;
 

--- a/tests/Unit/Utils/ArrayProcessors/IgnoreColumnsTest.php
+++ b/tests/Unit/Utils/ArrayProcessors/IgnoreColumnsTest.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Utils\ArrayProcessors;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\IgnoreColumns;
 
-class IgnoreColumnsTest extends TestCase
+final class IgnoreColumnsTest extends TestCase
 {
     public function testProcessorIgnoreColumns(): void
     {

--- a/tests/Unit/Utils/CsvFileTest.php
+++ b/tests/Unit/Utils/CsvFileTest.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors\RightTrim;
 use PhpCfdi\SatCatalogosPopulate\Utils\CsvFile;
 use RuntimeException;
 
-class CsvFileTest extends TestCase
+final class CsvFileTest extends TestCase
 {
     public function testConstructor(): void
     {
@@ -104,10 +104,10 @@ class CsvFileTest extends TestCase
         $csv = new CsvFile($this->utilFilePath('sample.csv'), new RightTrim());
 
         $contents = $csv->readLine();
-        $this->assertEquals($expected, $contents);
+        $this->assertSame($expected, $contents);
         $this->assertSame(0, $csv->position());
 
-        $this->assertEquals($expected, $csv->readLine());
+        $this->assertSame($expected, $csv->readLine());
     }
 
     public function testIterator(): void
@@ -128,7 +128,7 @@ class CsvFileTest extends TestCase
         }
 
         $this->assertSame(7, $count);
-        $this->assertEquals($expectedFirst, $first);
-        $this->assertEquals($expectedLast, $last);
+        $this->assertSame($expectedFirst, $first);
+        $this->assertSame($expectedLast, $last);
     }
 }

--- a/tests/convert-xls-to-csv-folder.php
+++ b/tests/convert-xls-to-csv-folder.php
@@ -30,5 +30,5 @@ exit(call_user_func(
         }
     },
     $argv[1] ?? '',
-    $argv[2] ?? tempdir()
+    $argv[2] ?? tempdir(),
 ));


### PR DESCRIPTION
This is an update to make the code compatible with PHP 8.4.
There are almost no compatibility backwards issues.

Change license year to 2026.

Other development changes:

- Bump to PHPUnit 11.5.
- Improve code using `rector/rector`.
- Add PHP 8.4 to test matrix.
- Run jobs using PHP 8.4 on GitHub workflows.
- Fix `composer-normalize` workflow.
- Update code standard for `phpcs` and `php-cs-fixer`.
- Improve docker file:
  - Run using Debian Trixie.
  - Improve PHP installation.
  - Clean APT packages.
  - Set up PHP timezone variable.
- Update development tools.

