### PR TITLE
Add support for *Nóminas 1.2 revisión E* and improve code base (version 3.0.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 
 # Actions
 # shivammathur/setup-php@v2 https://github.com/marketplace/actions/setup-php-action
+# browser-actions/setup-chrome@v2 https://github.com/marketplace/actions/setup-chrome
 # sudo-bot/action-scrutinizer@latest https://github.com/marketplace/actions/action-scrutinizer
 
 jobs:
@@ -117,7 +118,7 @@ jobs:
       - name: Install xlsx2csv & libreoffice-calc
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install -y -qq --no-install-recommends xlsx2csv default-jre-headless libreoffice-calc-nogui libreoffice-java-common chromium
+          sudo apt-get install -y -qq --no-install-recommends xlsx2csv default-jre-headless libreoffice-calc-nogui libreoffice-java-common
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Get composer cache directory
@@ -131,10 +132,13 @@ jobs:
           restore-keys: ${{ runner.os }}-composer-
       - name: Install project dependencies
         run: composer upgrade --no-interaction --no-progress --prefer-dist
+      - name: Set up Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
         env:
-          CHROME_BINARY: /usr/bin/chromium
+          CHROME_BINARY: ${{ steps.setup-chrome.outputs.chrome-path }}
       - name: Upload code coverage to scrutinizer
         if: github.event_name == 'push'
         uses: sudo-bot/action-scrutinizer@latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,11 +95,11 @@ jobs:
         run: phpstan analyse --no-progress --verbose
 
   tests:
-    name: Tests on PHP ${{ matrix.php-version }}
+    name: "Tests on PHP ${{ matrix.php-version }}"
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.2', '8.3', '8.4']
+        php-versions: ['8.3', '8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install xlsx2csv & libreoffice-calc
         run: |
           sudo apt-get update -y -qq
-          sudo apt-get install -y -qq --no-install-recommends xlsx2csv default-jre-headless libreoffice-calc-nogui libreoffice-java-common
+          sudo apt-get install -y -qq --no-install-recommends xlsx2csv default-jre-headless libreoffice-calc-nogui libreoffice-java-common chromium
         env:
           DEBIAN_FRONTEND: noninteractive
       - name: Get composer cache directory
@@ -133,6 +133,8 @@ jobs:
         run: composer upgrade --no-interaction --no-progress --prefer-dist
       - name: Tests (phpunit)
         run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
+        env:
+          CHROME_BINARY: /usr/bin/chromium
       - name: Upload code coverage to scrutinizer
         if: github.event_name == 'push'
         uses: sudo-bot/action-scrutinizer@latest
@@ -146,3 +148,5 @@ jobs:
           php bin/sat-catalogos-update dump-origins > build/files/origins.xml
           php bin/sat-catalogos-update update-origins build/files/
           php bin/sat-catalogos-update update-database build/files/ build/files/database.sqlite3
+        env:
+          CHROME_BINARY: /usr/bin/chromium

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,7 @@ jobs:
         env:
           CHROME_BINARY: ${{ steps.setup-chrome.outputs.chrome-path }}
           CHROME_NOSANDBOX: yes
+          PYTHONWARNINGS: ignore::SyntaxWarning
       - name: Upload code coverage to scrutinizer
         if: github.event_name == 'push'
         uses: sudo-bot/action-scrutinizer@latest
@@ -156,3 +157,4 @@ jobs:
         env:
           CHROME_BINARY: /usr/bin/chromium
           CHROME_NOSANDBOX: yes
+          PYTHONWARNINGS: ignore::SyntaxWarning

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.3', '8.4']
+        php-versions: ['8.4']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,7 @@ jobs:
         run: vendor/bin/phpunit --testdox --coverage-xml=build/coverage --coverage-clover=build/coverage/clover.xml --log-junit=build/coverage/junit.xml
         env:
           CHROME_BINARY: ${{ steps.setup-chrome.outputs.chrome-path }}
+          CHROME_NOSANDBOX: yes
       - name: Upload code coverage to scrutinizer
         if: github.event_name == 'push'
         uses: sudo-bot/action-scrutinizer@latest
@@ -154,3 +155,4 @@ jobs:
           php bin/sat-catalogos-update update-database build/files/ build/files/database.sqlite3
         env:
           CHROME_BINARY: /usr/bin/chromium
+          CHROME_NOSANDBOX: yes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.4']
+        php-versions: ['8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,14 +9,14 @@
 
 declare(strict_types=1);
 
-return (new PhpCsFixer\Config())
+return new PhpCsFixer\Config()
     ->setRiskyAllowed(true)
     ->setCacheFile(__DIR__ . '/build/php-cs-fixer.cache')
     ->setRules([
         '@PSR12' => true,
         '@PSR12:risky' => true,
-        '@PHP8x2Migration' => true,
-        '@PHP8x2Migration:risky' => true,
+        '@PHP8x4Migration' => true,
+        '@PHP8x4Migration:risky' => true,
         // symfony
         'array_indentation' => true,
         'class_attributes_separation' => true,

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN set -e \
     && rm -rf "$(composer config cache-dir --global)" "$(composer config data-dir --global)" "$(composer config home --global)"
 
 ENV CHROME_BINARY="/usr/bin/chromium"
+ENV CHROME_NOSANDBOX="yes"
 ENV TZ="America/Mexico_City"
 
 ENTRYPOINT ["/opt/sat-catalogos-populate/bin/sat-catalogos-update"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN set -e \
         php-cli php-curl php-zip php-sqlite3 php-xml \
     && apt-get install -y --no-install-recommends \
         libreoffice-calc-nogui default-jre-headless libreoffice-java-common \
+    && apt-get install -y --no-install-recommends \
+        chromium \
     # Clean APT \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -40,6 +42,7 @@ RUN set -e \
     && composer update --no-dev --prefer-dist --optimize-autoloader --no-interaction \
     && rm -rf "$(composer config cache-dir --global)" "$(composer config data-dir --global)" "$(composer config home --global)"
 
+ENV CHROME_BINARY="/usr/bin/chromium"
 ENV TZ="America/Mexico_City"
 
 ENTRYPOINT ["/opt/sat-catalogos-populate/bin/sat-catalogos-update"]

--- a/bin/sat-catalogos-update
+++ b/bin/sat-catalogos-update
@@ -14,8 +14,7 @@ error_reporting(-1);
 exit(call_user_func(function (string ...$arguments): int {
     $debug = true;
     try {
-        $cliApplication = new CliApplication();
-        return $cliApplication->run(...$arguments);
+        return new CliApplication()->run(...$arguments);
     } catch (Throwable $exception) {
         file_put_contents('php://stderr', 'ERROR: ' . $exception->getMessage() . PHP_EOL, FILE_APPEND);
         if ($debug) {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/phpcfdi/sat-catalogos-populate"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-pdo": "*",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "ext-dom": "*",
         "ext-json": "*",
         "ext-pdo": "*",
+        "ext-posix": "*",
         "ext-simplexml": "*",
         "ext-sqlite3": "*",
         "chrome-php/chrome": "^1.15",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "source": "https://github.com/phpcfdi/sat-catalogos-populate"
     },
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-pdo": "*",

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "ext-pdo": "*",
         "ext-simplexml": "*",
         "ext-sqlite3": "*",
+        "chrome-php/chrome": "^1.15",
         "guzzlehttp/guzzle": "^7.0",
         "psr/http-message": "^2.0",
         "psr/log": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "require-dev": {
         "ext-fileinfo": "*",
-        "phpunit/phpunit": "^11.5.46"
+        "phpunit/phpunit": "^12.5.4"
     },
     "autoload": {
         "psr-4": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,29 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 3.0.0 2026-01-09
+
+This is an update to be able to download *Nóminas 1.2 revisión E* catalog file.
+The resource URL requires a web browser that executes *javascript*.
+
+*Chrome* or *Chromium* is now required to obtain the resource address for *Nóminas 1.2 revisión E*.
+This version add `chrome-php/chrome` as a dependency.
+If chrome is not executable or detectable you can set the binary location on `CHROME_BINARY` variable.
+
+On this version, *Origin reviewers* change its namespace from
+`PhpCfdi\SatCatalogosPopulate\Origins` to `PhpCfdi\SatCatalogosPopulate\Origins\Reviewers`.
+
+Minimal PHP version is now 8.4.
+Compatibility with PHP 8.5 has been included.
+
+Function `str_getcsv` parameter `escape` bas been defined as empty string.
+All other values are deprecated.
+
+All classes that has the chance has been maked as `final` or `readonly`.
+
+Other changes:
+
+- PHPUnit has been upgrated to 12.5.
+
 ## Version 2.10.0 2026-01-08
 
 This is an update to make the code compatible with PHP 8.4.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,8 @@ The resource URL requires a web browser that executes *javascript*.
 
 *Chrome* or *Chromium* is now required to obtain the resource address for *Nóminas 1.2 revisión E*.
 This version add `chrome-php/chrome` as a dependency.
-If chrome is not executable or detectable you can set the binary location on `CHROME_BINARY` variable.
+If *Chrome* is not executable or detectable you can set the binary location on `CHROME_BINARY` variable.
+To run *Chrome* with *no sandbox* use `CHROME_NOSANDBOX=yes`.
 
 On this version, *Origin reviewers* change its namespace from
 `PhpCfdi\SatCatalogosPopulate\Origins` to `PhpCfdi\SatCatalogosPopulate\Origins\Reviewers`.

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -85,7 +85,7 @@ final class DumpOrigins implements CommandInterface
             new ConstantOrigin('CCP 3.1 - Carta Porte 3.1', "{$common}/CatalogosCartaPorte31.xls"),
         ]);
 
-        echo (new OriginsIO())->originsToString($origins) . PHP_EOL;
+        echo new OriginsIO()->originsToString($origins) . PHP_EOL;
 
         return 0;
     }

--- a/src/Commands/DumpOrigins.php
+++ b/src/Commands/DumpOrigins.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCfdi\SatCatalogosPopulate\Commands;
 
 use PhpCfdi\SatCatalogosPopulate\Origins\ConstantOrigin;
+use PhpCfdi\SatCatalogosPopulate\Origins\Nomina12eOrigin;
 use PhpCfdi\SatCatalogosPopulate\Origins\Origins;
 use PhpCfdi\SatCatalogosPopulate\Origins\OriginsIO;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
@@ -34,7 +35,7 @@ final class DumpOrigins implements CommandInterface
                 'ret_20.xls',
                 'Catálogos',
             ),
-            new ConstantOrigin('Nóminas', "{$common}/catNomina.xls"),
+            new Nomina12eOrigin("{$common}/catNomina.xls"),
             new ConstantOrigin('Nóminas - Estados', "{$common}/C_Estado.xls", null, 'nominas_estados.xls'),
             new ConstantOrigin('CCE 2.0 - Claves de pedimento', "{$common}/c_ClavePedimento20.xls"),
             new ConstantOrigin('CCE 2.0 - Colonias', "{$common}/c_Colonia20.xls"),

--- a/src/Commands/TerminalLogger.php
+++ b/src/Commands/TerminalLogger.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Commands;
 use Psr\Log\AbstractLogger;
 use Psr\Log\LogLevel;
 
-class TerminalLogger extends AbstractLogger
+final class TerminalLogger extends AbstractLogger
 {
     /**
      * @param string $level

--- a/src/Commands/UpdateOrigins.php
+++ b/src/Commands/UpdateOrigins.php
@@ -17,7 +17,7 @@ use RuntimeException;
 
 final class UpdateOrigins implements CommandInterface
 {
-    private const DEFAULT_ORIGINS_FILENAME = 'origins.xml';
+    private const string DEFAULT_ORIGINS_FILENAME = 'origins.xml';
 
     private readonly string $originsFile;
 

--- a/src/Commands/UpdateOrigins.php
+++ b/src/Commands/UpdateOrigins.php
@@ -73,12 +73,12 @@ final class UpdateOrigins implements CommandInterface
 
     protected function originsRestore(): Origins
     {
-        return (new OriginsIO())->readFile($this->getOriginsFile());
+        return new OriginsIO()->readFile($this->getOriginsFile());
     }
 
     protected function originsStore(Origins $origins): void
     {
-        (new OriginsIO())->writeFile($this->getOriginsFile(), $origins);
+        new OriginsIO()->writeFile($this->getOriginsFile(), $origins);
     }
 
     public function createResourcesGateway(): WebResourcesGateway

--- a/src/Commands/UpdateOrigins.php
+++ b/src/Commands/UpdateOrigins.php
@@ -8,7 +8,7 @@ use PhpCfdi\SatCatalogosPopulate\Database\Repository;
 use PhpCfdi\SatCatalogosPopulate\Importers\SourcesImporter;
 use PhpCfdi\SatCatalogosPopulate\Origins\Origins;
 use PhpCfdi\SatCatalogosPopulate\Origins\OriginsIO;
-use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\Reviewers;
 use PhpCfdi\SatCatalogosPopulate\Origins\ReviewStatus;
 use PhpCfdi\SatCatalogosPopulate\Origins\Upgrader;
 use PhpCfdi\SatCatalogosPopulate\Origins\WebResourcesGateway;

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -148,7 +148,7 @@ class CsvFolderJoinFiles
         return implode(',', array_rtrim(
             array_map(
                 static fn (string|null $value): string => trim($value ?? ''),
-                str_getcsv($current),
+                str_getcsv($current, escape: ''),
             ),
         ));
     }

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -157,13 +157,10 @@ class CsvFolderJoinFiles
     public function lastLineContains(string $filename, array $searchterms): bool
     {
         $lastline = $this->obtainFileLastLine($filename);
-        foreach ($searchterms as $search) {
-            if (str_contains($lastline, $search)) {
-                return true;
-            }
-        }
-
-        return false;
+        return array_any(
+            $searchterms,
+            static fn ($search) => str_contains($lastline, (string) $search),
+        );
     }
 
     public function obtainFileLastLine(string $filename): string

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -148,7 +148,7 @@ class CsvFolderJoinFiles
         return implode(',', array_rtrim(
             array_map(
                 static fn (string|null $value): string => trim($value ?? ''),
-                str_getcsv($current, escape: '\\'),
+                str_getcsv($current),
             ),
         ));
     }

--- a/src/Converters/CsvFolderJoinFiles.php
+++ b/src/Converters/CsvFolderJoinFiles.php
@@ -9,7 +9,7 @@ use SplFileObject;
 
 use function PhpCfdi\SatCatalogosPopulate\Utils\array_rtrim;
 
-class CsvFolderJoinFiles
+final class CsvFolderJoinFiles
 {
     public function joinFilesInFolder(string $csvFolder): void
     {

--- a/src/Converters/XlsToCsvFolderConverter.php
+++ b/src/Converters/XlsToCsvFolderConverter.php
@@ -14,11 +14,11 @@ class XlsToCsvFolderConverter
 
         try {
             // convert from XLS to XLSX
-            $xlsToXlsxConverter = new XlsToXlsxConverter();
+            $xlsToXlsxConverter = XlsToXlsxConverter::create();
             $xlsToXlsxConverter->convert($source, $xlsxDestination);
 
             // convert from XLSX to CSV
-            $xlsxToCsvFolder = new XlsxToCsvFolderConverter();
+            $xlsxToCsvFolder = XlsxToCsvFolderConverter::create();
             $xlsxToCsvFolder->convert($xlsxDestination, $destination);
 
             // join files that are in two or more files

--- a/src/Converters/XlsxToCsvFolderConverter.php
+++ b/src/Converters/XlsxToCsvFolderConverter.php
@@ -4,23 +4,27 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Converters;
 
+use InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\Utils\ShellExec;
 use PhpCfdi\SatCatalogosPopulate\Utils\WhichTrait;
 use RuntimeException;
 
-class XlsxToCsvFolderConverter
+final readonly class XlsxToCsvFolderConverter
 {
     use WhichTrait;
 
-    /** @var string Location of xlsx2csvPath executable */
-    private readonly string $xlsx2csvPath;
-
-    public function __construct(string $xlsx2csvPath = '')
+    /** @param string $xlsx2csvPath Location of xlsx2csvPath executable */
+    public function __construct(private string $xlsx2csvPath)
     {
-        if ('' === $xlsx2csvPath) {
-            $xlsx2csvPath = $this->which('xlsx2csv');
+        if ('' === $this->xlsx2csvPath) {
+            throw new InvalidArgumentException('xlsx2csv path must not be empty.');
         }
-        $this->xlsx2csvPath = $xlsx2csvPath;
+    }
+
+    public static function create(): self
+    {
+        $xlsx2csvPath = self::which('xlsx2csv');
+        return new self($xlsx2csvPath);
     }
 
     public function xlsx2csvPath(): string

--- a/src/Database/BoolDataField.php
+++ b/src/Database/BoolDataField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Database;
 
-class BoolDataField extends AbstractDataField implements DataFieldInterface
+final class BoolDataField extends AbstractDataField implements DataFieldInterface
 {
     /**
      * @param string[] $trueValues

--- a/src/Database/DataFields.php
+++ b/src/Database/DataFields.php
@@ -14,28 +14,27 @@ use UnexpectedValueException;
 /**
  * @implements IteratorAggregate<DataFieldInterface>
  */
-class DataFields implements Countable, IteratorAggregate
+final readonly class DataFields implements Countable, IteratorAggregate
 {
     /** @var array<string, DataFieldInterface> */
-    private array $map = [];
+    private array $map;
 
-    /**
-     * @param DataFieldInterface[] $dataFields
-     */
+    /** @param DataFieldInterface[] $dataFields */
     public function __construct(array $dataFields)
     {
+        $map = [];
         foreach ($dataFields as $dataField) {
             /** @phpstan-ignore-next-line instanceof.alwaysTrue */
             if (! $dataField instanceof DataFieldInterface) {
                 throw new InvalidArgumentException('There is a datafield with invalid type');
             }
-            $this->map[$dataField->name()] = $dataField;
+            $map[$dataField->name()] = $dataField;
         }
+
+        $this->map = $map;
     }
 
-    /**
-     * @return string[]
-     */
+    /** @return string[] */
     public function keys(): array
     {
         return array_keys($this->map);

--- a/src/Database/DataTable.php
+++ b/src/Database/DataTable.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 
 use LogicException;
 
-readonly class DataTable
+final readonly class DataTable
 {
     private string $name;
 

--- a/src/Database/DataTable.php
+++ b/src/Database/DataTable.php
@@ -6,14 +6,14 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 
 use LogicException;
 
-class DataTable
+readonly class DataTable
 {
-    private readonly string $name;
+    private string $name;
 
-    private readonly DataFields $fields;
+    private DataFields $fields;
 
     /** @var string[] */
-    private readonly array $primaryKey;
+    private array $primaryKey;
 
     /**
      * @param string[] $primaryKey

--- a/src/Database/DataTableGateway.php
+++ b/src/Database/DataTableGateway.php
@@ -7,9 +7,9 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 use LogicException;
 use PDOException;
 
-class DataTableGateway
+readonly class DataTableGateway
 {
-    public function __construct(private readonly DataTable $dataTable, private readonly Repository $repository)
+    public function __construct(private DataTable $dataTable, private Repository $repository)
     {
     }
 

--- a/src/Database/DataTableGateway.php
+++ b/src/Database/DataTableGateway.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 use LogicException;
 use PDOException;
 
-readonly class DataTableGateway
+final readonly class DataTableGateway
 {
     public function __construct(private DataTable $dataTable, private Repository $repository)
     {

--- a/src/Database/DateDataField.php
+++ b/src/Database/DateDataField.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 use DateTime;
 use RuntimeException;
 
-class DateDataField extends AbstractDataField implements DataFieldInterface
+final class DateDataField extends AbstractDataField implements DataFieldInterface
 {
     public function __construct(string $name)
     {

--- a/src/Database/FloatDataField.php
+++ b/src/Database/FloatDataField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Database;
 
-class FloatDataField extends AbstractDataField implements DataFieldInterface
+final class FloatDataField extends AbstractDataField implements DataFieldInterface
 {
     public function __construct(string $name)
     {

--- a/src/Database/IntegerDataField.php
+++ b/src/Database/IntegerDataField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Database;
 
-class IntegerDataField extends AbstractDataField implements DataFieldInterface
+final class IntegerDataField extends AbstractDataField implements DataFieldInterface
 {
     public function __construct(string $name)
     {

--- a/src/Database/NumberFormatDataField.php
+++ b/src/Database/NumberFormatDataField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Database;
 
-class NumberFormatDataField extends TextDataField implements DataFieldInterface
+final class NumberFormatDataField extends TextDataField implements DataFieldInterface
 {
     public function __construct(string $name, int $decimals)
     {

--- a/src/Database/PaddingDataField.php
+++ b/src/Database/PaddingDataField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Database;
 
-class PaddingDataField extends TextDataField implements DataFieldInterface
+final class PaddingDataField extends TextDataField implements DataFieldInterface
 {
     public function __construct(string $name, string $padding, int $length)
     {

--- a/src/Database/Repository.php
+++ b/src/Database/Repository.php
@@ -8,9 +8,9 @@ use PDO;
 use PDOException;
 use RuntimeException;
 
-class Repository
+readonly class Repository
 {
-    private readonly PDO $pdo;
+    private PDO $pdo;
 
     public function __construct(string $dbfile)
     {

--- a/src/Database/Repository.php
+++ b/src/Database/Repository.php
@@ -8,7 +8,7 @@ use PDO;
 use PDOException;
 use RuntimeException;
 
-readonly class Repository
+final readonly class Repository
 {
     private PDO $pdo;
 

--- a/src/Database/TextDataField.php
+++ b/src/Database/TextDataField.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Database;
 
 class TextDataField extends AbstractDataField implements DataFieldInterface
 {
-    public const MB_CHAR_NBSP = "\xC2\xA0";
+    public const string MB_CHAR_NBSP = "\xC2\xA0";
 
     public function transform($input)
     {

--- a/src/Database/ToBeDefinedDataField.php
+++ b/src/Database/ToBeDefinedDataField.php
@@ -29,11 +29,9 @@ final class ToBeDefinedDataField extends PreprocessDataField
         }
 
         $input = trim(strval($input));
-        foreach ($this->toBeDefinedTexts as $toBeDefinedText) {
-            if (0 === strcasecmp($toBeDefinedText, $input)) {
-                return true;
-            }
-        }
-        return false;
+        return array_any(
+            $this->toBeDefinedTexts,
+            static fn ($toBeDefinedText) => 0 === strcasecmp((string) $toBeDefinedText, $input),
+        );
     }
 }

--- a/src/Importers/Cfdi/Injectors/FormasDePago.php
+++ b/src/Importers/Cfdi/Injectors/FormasDePago.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors;
 
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\BoolDataField;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;

--- a/src/Importers/Cfdi/Injectors/Paises.php
+++ b/src/Importers/Cfdi/Injectors/Paises.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi\Injectors;
 
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;
 use PhpCfdi\SatCatalogosPopulate\Database\DataTable;

--- a/src/Importers/Cfdi40/Injectors/FormasDePago.php
+++ b/src/Importers/Cfdi40/Injectors/FormasDePago.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors;
 
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\BoolDataField;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;

--- a/src/Importers/Cfdi40/Injectors/Paises.php
+++ b/src/Importers/Cfdi40/Injectors/Paises.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Importers\Cfdi40\Injectors;
 
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use PhpCfdi\SatCatalogosPopulate\AbstractCsvInjector;
 use PhpCfdi\SatCatalogosPopulate\Database\DataFields;
 use PhpCfdi\SatCatalogosPopulate\Database\DataTable;

--- a/src/Injectors.php
+++ b/src/Injectors.php
@@ -11,7 +11,7 @@ use Psr\Log\LoggerInterface;
 /**
  * @extends AbstractCollection<InjectorInterface>
  */
-class Injectors extends AbstractCollection implements InjectorInterface
+final class Injectors extends AbstractCollection implements InjectorInterface
 {
     public function __construct(array $members)
     {

--- a/src/Origins/ConstantOrigin.php
+++ b/src/Origins/ConstantOrigin.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use InvalidArgumentException;
 use LogicException;
 
-class ConstantOrigin implements OriginInterface
+final class ConstantOrigin implements OriginInterface
 {
     private string $destinationFilename;
 

--- a/src/Origins/Nomina12eOrigin.php
+++ b/src/Origins/Nomina12eOrigin.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatCatalogosPopulate\Origins;
+
+use DateTimeImmutable;
+use LogicException;
+
+final readonly class Nomina12eOrigin implements OriginInterface
+{
+    private string $name;
+
+    private string $downloadUrl;
+
+    public function __construct(
+        private string $destinationFilename = '',
+        private ?DateTimeImmutable $lastVersion = null,
+    ) {
+        $this->name = 'Nómina 12e';
+        $this->downloadUrl = 'https://www.sat.gob.mx/portal/public/tramites/complemento-de-nomina';
+    }
+
+    public function withLastModified(?DateTimeImmutable $lastModified): static
+    {
+        return new self($this->destinationFilename, $lastModified);
+    }
+
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    public function url(): string
+    {
+        return $this->downloadUrl();
+    }
+
+    public function lastVersion(): DateTimeImmutable
+    {
+        if (! $this->lastVersion instanceof DateTimeImmutable) {
+            throw new LogicException('There is no last version in the origin');
+        }
+        return $this->lastVersion;
+    }
+
+    public function hasLastVersion(): bool
+    {
+        return $this->lastVersion instanceof DateTimeImmutable;
+    }
+
+    public function destinationFilename(): string
+    {
+        return $this->destinationFilename;
+    }
+
+    public function downloadUrl(): string
+    {
+        return $this->downloadUrl;
+    }
+}

--- a/src/Origins/Origins.php
+++ b/src/Origins/Origins.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\AbstractCollection;
 /**
  * @extends AbstractCollection<OriginInterface>
  */
-class Origins extends AbstractCollection
+final class Origins extends AbstractCollection
 {
     public function isValidMember(mixed $member): bool
     {

--- a/src/Origins/OriginsIO.php
+++ b/src/Origins/OriginsIO.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 use DOMDocument;
 use SimpleXMLElement;
 
-readonly class OriginsIO
+final readonly class OriginsIO
 {
     private OriginsTranslator $translator;
 

--- a/src/Origins/OriginsIO.php
+++ b/src/Origins/OriginsIO.php
@@ -7,9 +7,9 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 use DOMDocument;
 use SimpleXMLElement;
 
-class OriginsIO
+readonly class OriginsIO
 {
-    private readonly OriginsTranslator $translator;
+    private OriginsTranslator $translator;
 
     public function __construct()
     {

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -19,6 +19,9 @@ final class OriginsTranslator implements OriginsTranslatorInterface
         if ('scrap' === $type) {
             return $this->scrapingOriginFromArray($data);
         }
+        if ('nomina12e' === $type) {
+            return $this->nomina12eOriginFromArray($data);
+        }
         throw new RuntimeException("Unable to create an origin with type $type");
     }
 
@@ -42,6 +45,9 @@ final class OriginsTranslator implements OriginsTranslatorInterface
         if ($origin instanceof ScrapingOrigin) {
             return $this->scrapingOriginToArray($origin);
         }
+        if ($origin instanceof Nomina12eOrigin) {
+            return $this->constantNomina12eToArray($origin);
+        }
         throw new RuntimeException(sprintf('Unable to export an origin with type %s', $origin::class));
     }
 
@@ -55,6 +61,15 @@ final class OriginsTranslator implements OriginsTranslatorInterface
             strval($data['link-text'] ?? ''),
             $this->dateTimeFromStringOrNull(strval($data['last-update'] ?? '')),
             linkPosition: intval($data['link-position'] ?? 0),
+        );
+    }
+
+    /** @param array<string, string> $data */
+    public function nomina12eOriginFromArray(array $data): Nomina12eOrigin
+    {
+        return new Nomina12eOrigin(
+            strval($data['destination-file'] ?? ''),
+            $this->dateTimeFromStringOrNull(strval($data['last-update'] ?? '')),
         );
     }
 
@@ -88,4 +103,14 @@ final class OriginsTranslator implements OriginsTranslatorInterface
             'link-position' => strval($origin->linkPosition()),
         ]);
     }
+
+    public function constantNomina12eToArray(Nomina12eOrigin $origin): array
+    {
+        return array_filter([
+            'type' => 'nomina12e',
+            'destination-file' => $origin->destinationFilename(),
+            'last-update' => ($origin->hasLastVersion()) ? $origin->lastVersion()->format('c') : '',
+        ]);
+    }
+
 }

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -104,6 +104,7 @@ final class OriginsTranslator implements OriginsTranslatorInterface
         ]);
     }
 
+    /** @return array<string, string> */
     public function constantNomina12eToArray(Nomina12eOrigin $origin): array
     {
         return array_filter([

--- a/src/Origins/OriginsTranslator.php
+++ b/src/Origins/OriginsTranslator.php
@@ -112,5 +112,4 @@ final class OriginsTranslator implements OriginsTranslatorInterface
             'last-update' => ($origin->hasLastVersion()) ? $origin->lastVersion()->format('c') : '',
         ]);
     }
-
 }

--- a/src/Origins/Review.php
+++ b/src/Origins/Review.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
-class Review
+readonly class Review
 {
-    public function __construct(private readonly OriginInterface $origin, private readonly ReviewStatus $status)
+    public function __construct(private OriginInterface $origin, private ReviewStatus $status)
     {
     }
 

--- a/src/Origins/Review.php
+++ b/src/Origins/Review.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
-readonly class Review
+final readonly class Review
 {
     public function __construct(private OriginInterface $origin, private ReviewStatus $status)
     {

--- a/src/Origins/ReviewStatus.php
+++ b/src/Origins/ReviewStatus.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
-class ReviewStatus
+final class ReviewStatus
 {
     protected const string UP_TO_DATE = 'UP-TO-DATE';
 

--- a/src/Origins/ReviewStatus.php
+++ b/src/Origins/ReviewStatus.php
@@ -6,11 +6,11 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
 class ReviewStatus
 {
-    protected const UP_TO_DATE = 'UP-TO-DATE';
+    protected const string UP_TO_DATE = 'UP-TO-DATE';
 
-    protected const NOT_FOUND = 'NOT-FOUND';
+    protected const string NOT_FOUND = 'NOT-FOUND';
 
-    protected const NOT_UPDATED = 'NOT-UPDATED';
+    protected const string NOT_UPDATED = 'NOT-UPDATED';
 
     private function __construct(private readonly string $status)
     {

--- a/src/Origins/Reviewers/ConstantReviewer.php
+++ b/src/Origins/Reviewers/ConstantReviewer.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
 
 use LogicException;
+use PhpCfdi\SatCatalogosPopulate\Origins\ConstantOrigin;
+use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Review;
+use PhpCfdi\SatCatalogosPopulate\Origins\ReviewStatus;
 
 class ConstantReviewer implements ReviewerInterface
 {

--- a/src/Origins/Reviewers/ConstantReviewer.php
+++ b/src/Origins/Reviewers/ConstantReviewer.php
@@ -11,7 +11,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\Review;
 use PhpCfdi\SatCatalogosPopulate\Origins\ReviewStatus;
 
-readonly class ConstantReviewer implements ReviewerInterface
+final readonly class ConstantReviewer implements ReviewerInterface
 {
     public function __construct(private ResourcesGatewayInterface $gateway)
     {

--- a/src/Origins/Reviewers/ConstantReviewer.php
+++ b/src/Origins/Reviewers/ConstantReviewer.php
@@ -11,9 +11,9 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\Review;
 use PhpCfdi\SatCatalogosPopulate\Origins\ReviewStatus;
 
-class ConstantReviewer implements ReviewerInterface
+readonly class ConstantReviewer implements ReviewerInterface
 {
-    public function __construct(private readonly ResourcesGatewayInterface $gateway)
+    public function __construct(private ResourcesGatewayInterface $gateway)
     {
     }
 

--- a/src/Origins/Reviewers/Nomina12eReviewer.php
+++ b/src/Origins/Reviewers/Nomina12eReviewer.php
@@ -54,7 +54,11 @@ final class Nomina12eReviewer implements ReviewerInterface
     /** @throws Exception when something goes wrong */
     public function obtainResourceUrl(): string
     {
-        $browserFactory = new BrowserFactory();
+        $chromeBinary = $this->obtainChromeBinary();
+        $browserFactory = new BrowserFactory($chromeBinary);
+        if (0 === posix_getuid()) {
+            $browserFactory->addOptions(['noSandbox' => true]);
+        }
         $browser = $browserFactory->createBrowser();
         try {
             // creates a new page and navigate to a URL
@@ -95,5 +99,15 @@ final class Nomina12eReviewer implements ReviewerInterface
         } finally {
             $browser->close();
         }
+    }
+
+    private function obtainChromeBinary(): string|null
+    {
+        $chromeBinary = $_SERVER['CHROME_BINARY'] ?? null;
+        if (! is_scalar($chromeBinary) && ! is_null($chromeBinary)) {
+            return null;
+        }
+
+        return is_scalar($chromeBinary) ? (string) $chromeBinary : null;
     }
 }

--- a/src/Origins/Reviewers/Nomina12eReviewer.php
+++ b/src/Origins/Reviewers/Nomina12eReviewer.php
@@ -56,9 +56,7 @@ final class Nomina12eReviewer implements ReviewerInterface
     {
         $chromeBinary = $this->obtainChromeBinary();
         $browserFactory = new BrowserFactory($chromeBinary);
-        if (0 === posix_getuid()) {
-            $browserFactory->addOptions(['noSandbox' => true]);
-        }
+        $browserFactory->addOptions(['noSandbox' => $this->obtainChromeNoSandbox()]);
         $browser = $browserFactory->createBrowser();
         try {
             // creates a new page and navigate to a URL
@@ -109,5 +107,14 @@ final class Nomina12eReviewer implements ReviewerInterface
         }
 
         return is_scalar($chromeBinary) ? (string) $chromeBinary : null;
+    }
+
+    private function obtainChromeNoSandbox(): bool
+    {
+        $chromeNoSandbox = $_SERVER['CHROME_NOSANDBOX'] ?? null;
+        if (is_string($chromeNoSandbox)) {
+            return in_array(strtolower($chromeNoSandbox), ['yes', 'true'], true);
+        }
+        return false;
     }
 }

--- a/src/Origins/Reviewers/Nomina12eReviewer.php
+++ b/src/Origins/Reviewers/Nomina12eReviewer.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
+
+use Exception;
+use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Dom\Selector\XPathSelector;
+use LogicException;
+use PhpCfdi\SatCatalogosPopulate\Origins\ConstantOrigin;
+use PhpCfdi\SatCatalogosPopulate\Origins\Nomina12eOrigin;
+use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Review;
+use RuntimeException;
+
+final class Nomina12eReviewer implements ReviewerInterface
+{
+    private const string NOMINA_12E_URL = 'https://www.sat.gob.mx/portal/public/tramites/complemento-de-nomina';
+
+    public function __construct(
+        private readonly ResourcesGatewayInterface $gateway,
+    ) {
+    }
+
+    public function accepts(OriginInterface $origin): bool
+    {
+        return $origin instanceof Nomina12eOrigin;
+    }
+
+    public function review(OriginInterface $origin): Review
+    {
+        if (! $this->accepts($origin)) {
+            throw new LogicException('This reviewer can only handle Nomina12eOrigin objects');
+        }
+
+        try {
+            $resourceUrl = $this->obtainResourceUrl();
+        } catch (Exception $exception) {
+            throw new RuntimeException('Unable to obtain resource URL for Nómina 12e', previous: $exception);
+        }
+
+        $origin = new ConstantOrigin(
+            $origin->name(),
+            $resourceUrl,
+            ($origin->hasLastVersion()) ? $origin->lastVersion() : null,
+            $origin->destinationFilename(),
+        );
+        $reviewer = new ConstantReviewer($this->gateway);
+        return $reviewer->review($origin);
+    }
+
+    /** @throws Exception when something goes wrong */
+    public function obtainResourceUrl(): string
+    {
+        $browserFactory = new BrowserFactory();
+        $browser = $browserFactory->createBrowser();
+        try {
+            // creates a new page and navigate to a URL
+            $page = $browser->createPage();
+            $page->navigate(self::NOMINA_12E_URL)->waitForNavigation(timeout: 10_000);
+
+            // wait until there is a div.tab-container div.tab-label with text Información especializada
+            $tabSelector = new XPathSelector(implode('', [
+                '//div[contains(@class, "tab-container")]',
+                '//div[contains(@class, "tab-label")]',
+                '//span[contains(text(), "Información especializada")]',
+            ]));
+            $page->waitUntilContainsElement($tabSelector);
+            // click on the element
+            $page->mouse()->findElement($tabSelector)->click();
+
+            // wait for the loaded content
+            $page->waitUntilContainsElement(
+                new XPathSelector('//div[contains(@class, "tab-content")]'),
+            );
+            // search for every tab-content a that contains Catálogos del complemento
+            $contentElements = $page->dom()->search(implode('', ['',
+                '//div[contains(@class, "tab-content")]',
+                '//a[contains(text(), "Catálogos del complemento")]',
+            ]));
+            if ([] === $contentElements) {
+                throw new RuntimeException('Unable to find links');
+            }
+
+            // return href from element that contains href
+            foreach ($contentElements as $contentElement) {
+                $href = $contentElement->getAttribute('href');
+                if (null !== $href) {
+                    return $href;
+                }
+            }
+            throw new RuntimeException('Unable to find URL on elements matching "Catálogos del complemento"');
+        } finally {
+            $browser->close();
+        }
+    }
+}

--- a/src/Origins/Reviewers/ReviewerInterface.php
+++ b/src/Origins/Reviewers/ReviewerInterface.php
@@ -2,7 +2,10 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
+
+use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Review;
 
 interface ReviewerInterface
 {

--- a/src/Origins/Reviewers/Reviewers.php
+++ b/src/Origins/Reviewers/Reviewers.php
@@ -10,7 +10,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\Origins;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\Reviews;
 
-readonly class Reviewers
+final readonly class Reviewers
 {
     /** @var ReviewerInterface[] */
     private array $reviewers;

--- a/src/Origins/Reviewers/Reviewers.php
+++ b/src/Origins/Reviewers/Reviewers.php
@@ -2,9 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
 
 use LogicException;
+use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Origins;
+use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviews;
 
 class Reviewers
 {

--- a/src/Origins/Reviewers/Reviewers.php
+++ b/src/Origins/Reviewers/Reviewers.php
@@ -10,10 +10,10 @@ use PhpCfdi\SatCatalogosPopulate\Origins\Origins;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\Reviews;
 
-class Reviewers
+readonly class Reviewers
 {
     /** @var ReviewerInterface[] */
-    private readonly array $reviewers;
+    private array $reviewers;
 
     public function __construct(ReviewerInterface ...$reviewers)
     {

--- a/src/Origins/Reviewers/Reviewers.php
+++ b/src/Origins/Reviewers/Reviewers.php
@@ -25,6 +25,7 @@ class Reviewers
         return new self(...[
             new ConstantReviewer($gateway),
             new ScrapingReviewer($gateway),
+            new Nomina12eReviewer($gateway),
         ]);
     }
 

--- a/src/Origins/Reviewers/ScrapingReviewer.php
+++ b/src/Origins/Reviewers/ScrapingReviewer.php
@@ -14,9 +14,9 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewerLinkExtractor;
 use PhpCfdi\SatCatalogosPopulate\Origins\UrlResponse;
 use RuntimeException;
 
-class ScrapingReviewer implements ReviewerInterface
+readonly class ScrapingReviewer implements ReviewerInterface
 {
-    public function __construct(private readonly ResourcesGatewayInterface $gateway)
+    public function __construct(private ResourcesGatewayInterface $gateway)
     {
     }
 

--- a/src/Origins/Reviewers/ScrapingReviewer.php
+++ b/src/Origins/Reviewers/ScrapingReviewer.php
@@ -2,9 +2,16 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
 
 use LogicException;
+use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Review;
+use PhpCfdi\SatCatalogosPopulate\Origins\ReviewStatus;
+use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
+use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewerLinkExtractor;
+use PhpCfdi\SatCatalogosPopulate\Origins\UrlResponse;
 use RuntimeException;
 
 class ScrapingReviewer implements ReviewerInterface

--- a/src/Origins/Reviewers/ScrapingReviewer.php
+++ b/src/Origins/Reviewers/ScrapingReviewer.php
@@ -14,7 +14,7 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewerLinkExtractor;
 use PhpCfdi\SatCatalogosPopulate\Origins\UrlResponse;
 use RuntimeException;
 
-readonly class ScrapingReviewer implements ReviewerInterface
+final readonly class ScrapingReviewer implements ReviewerInterface
 {
     public function __construct(private ResourcesGatewayInterface $gateway)
     {

--- a/src/Origins/Reviews.php
+++ b/src/Origins/Reviews.php
@@ -9,7 +9,7 @@ use PhpCfdi\SatCatalogosPopulate\AbstractCollection;
 /**
  * @extends AbstractCollection<Review>
  */
-class Reviews extends AbstractCollection
+final class Reviews extends AbstractCollection
 {
     public function isValidMember(mixed $member): bool
     {

--- a/src/Origins/ScrapingOrigin.php
+++ b/src/Origins/ScrapingOrigin.php
@@ -7,7 +7,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 use DateTimeImmutable;
 use LogicException;
 
-class ScrapingOrigin implements OriginInterface
+final class ScrapingOrigin implements OriginInterface
 {
     public function __construct(
         private readonly string $name,

--- a/src/Origins/Upgrader.php
+++ b/src/Origins/Upgrader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Origins;
 
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\Reviewers;
 use Psr\Log\LoggerInterface;
 
 // use function PhpCfdi\SatCatalogosPopulate\Utils\file_extension;

--- a/src/Origins/Upgrader.php
+++ b/src/Origins/Upgrader.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerInterface;
 
 class Upgrader
 {
-    final public const DEFAULT_ORIGINS_FILENAME = 'origins.xml';
+    final public const string DEFAULT_ORIGINS_FILENAME = 'origins.xml';
 
     public function __construct(
         private readonly ResourcesGatewayInterface $gateway,

--- a/src/Origins/Upgrader.php
+++ b/src/Origins/Upgrader.php
@@ -7,11 +7,9 @@ namespace PhpCfdi\SatCatalogosPopulate\Origins;
 use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\Reviewers;
 use Psr\Log\LoggerInterface;
 
-// use function PhpCfdi\SatCatalogosPopulate\Utils\file_extension;
-
-class Upgrader
+final class Upgrader
 {
-    final public const string DEFAULT_ORIGINS_FILENAME = 'origins.xml';
+    public const string DEFAULT_ORIGINS_FILENAME = 'origins.xml';
 
     public function __construct(
         private readonly ResourcesGatewayInterface $gateway,
@@ -92,25 +90,4 @@ class Upgrader
         $urlResponse = $this->gateway->get($origin->downloadUrl(), $destination);
         return $origin->withLastModified($urlResponse->lastModified());
     }
-
-    /*
-    protected function createBackup(string $currentFile)
-    {
-        if (! file_exists($currentFile)) {
-            return;
-        }
-        $extension = file_extension($currentFile);
-        $currentDate = (new \DateTimeImmutable())->setTimestamp(filectime($currentFile));
-        $backupFile = sprintf(
-            '%s-%s.%s',
-            substr($currentFile, 0, - 1 - strlen($extension)), // current name without extension
-            $currentDate->format('Ymd-HisO'),                  // date
-            $extension                                         // extension
-        );
-        if (! file_exists($backupFile)) {
-            $this->logger->info(sprintf('Respaldando %s en %s', $currentFile, $backupFile));
-            copy($currentFile, $backupFile);
-        }
-    }
-    */
 }

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -8,15 +8,15 @@ use DateTimeImmutable;
 use Psr\Http\Message\ResponseInterface;
 use Stringable;
 
-class UrlResponse
+readonly class UrlResponse
 {
-    private readonly DateTimeImmutable $lastModified;
+    private DateTimeImmutable $lastModified;
 
     public function __construct(
-        private readonly string $url,
-        private readonly int $httpStatus,
+        private string $url,
+        private int $httpStatus,
         DateTimeImmutable|null $lastModified = null,
-        private readonly Stringable|string $body = '',
+        private Stringable|string $body = '',
     ) {
         $this->lastModified = ($lastModified) ?: new DateTimeImmutable();
     }

--- a/src/Origins/UrlResponse.php
+++ b/src/Origins/UrlResponse.php
@@ -8,25 +8,23 @@ use DateTimeImmutable;
 use Psr\Http\Message\ResponseInterface;
 use Stringable;
 
-readonly class UrlResponse
+final readonly class UrlResponse
 {
-    private DateTimeImmutable $lastModified;
-
     public function __construct(
         private string $url,
         private int $httpStatus,
-        DateTimeImmutable|null $lastModified = null,
+        private DateTimeImmutable $lastModified = new DateTimeImmutable(),
         private Stringable|string $body = '',
     ) {
-        $this->lastModified = ($lastModified) ?: new DateTimeImmutable();
     }
 
     public static function createFromResponse(ResponseInterface $response, string $url): self
     {
-        $lastModified = null;
         if ($response->hasHeader('Last-Modified')) {
             /** @noinspection PhpUnhandledExceptionInspection */
             $lastModified = new DateTimeImmutable($response->getHeaderLine('Last-Modified'));
+        } else {
+            $lastModified = new DateTimeImmutable();
         }
 
         return new self($url, $response->getStatusCode(), $lastModified, $response->getBody());

--- a/src/Origins/WebResourcesGateway.php
+++ b/src/Origins/WebResourcesGateway.php
@@ -11,13 +11,10 @@ use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 
-readonly class WebResourcesGateway implements ResourcesGatewayInterface
+final readonly class WebResourcesGateway implements ResourcesGatewayInterface
 {
-    private GuzzleClient $client;
-
-    public function __construct(GuzzleClient|null $client = null)
+    public function __construct(private GuzzleClient $client = new GuzzleClient())
     {
-        $this->client = $client ?? new GuzzleClient();
     }
 
     private function obtainResponse(string $method, string $url): ResponseInterface

--- a/src/Origins/WebResourcesGateway.php
+++ b/src/Origins/WebResourcesGateway.php
@@ -11,9 +11,9 @@ use GuzzleHttp\RequestOptions;
 use Psr\Http\Message\ResponseInterface;
 use RuntimeException;
 
-class WebResourcesGateway implements ResourcesGatewayInterface
+readonly class WebResourcesGateway implements ResourcesGatewayInterface
 {
-    private readonly GuzzleClient $client;
+    private GuzzleClient $client;
 
     public function __construct(GuzzleClient|null $client = null)
     {

--- a/src/Utils/ArrayProcessors/IgnoreColumns.php
+++ b/src/Utils/ArrayProcessors/IgnoreColumns.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors;
 
-class IgnoreColumns extends AbstractPipeArrayProcessor implements ArrayProcessorInterface
+final class IgnoreColumns extends AbstractPipeArrayProcessor implements ArrayProcessorInterface
 {
     /** @var array<int, int> */
     private readonly array $columns;

--- a/src/Utils/ArrayProcessors/NullArrayProcessor.php
+++ b/src/Utils/ArrayProcessors/NullArrayProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors;
 
-class NullArrayProcessor implements ArrayProcessorInterface
+final class NullArrayProcessor implements ArrayProcessorInterface
 {
     /** @inheritdoc */
     public function execute(array $array): array

--- a/src/Utils/ArrayProcessors/RightTrim.php
+++ b/src/Utils/ArrayProcessors/RightTrim.php
@@ -6,7 +6,7 @@ namespace PhpCfdi\SatCatalogosPopulate\Utils\ArrayProcessors;
 
 use function PhpCfdi\SatCatalogosPopulate\Utils\array_rtrim;
 
-class RightTrim extends AbstractPipeArrayProcessor implements ArrayProcessorInterface
+final class RightTrim extends AbstractPipeArrayProcessor implements ArrayProcessorInterface
 {
     /** @inheritdoc */
     public function execute(array $array): array

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -15,11 +15,11 @@ use UnexpectedValueException;
 /**
  * @implements SeekableIterator<int, array<int, scalar>>
  */
-class CsvFile implements SeekableIterator
+readonly class CsvFile implements SeekableIterator
 {
-    private readonly SplFileObject $file;
+    private SplFileObject $file;
 
-    private readonly ArrayProcessorInterface $rowProcessor;
+    private ArrayProcessorInterface $rowProcessor;
 
     public function __construct(string $filename, ArrayProcessorInterface|null $rowProcessor = null)
     {
@@ -110,7 +110,7 @@ class CsvFile implements SeekableIterator
         $contents = (is_string($contents)) ? $contents : '';
         $values = array_map(
             static fn ($value): string => (is_scalar($value)) ? $value : '',
-            str_getcsv($contents, escape: '\\'),
+            str_getcsv($contents),
         );
         return $this->rowProcessor->execute($values);
     }

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -110,7 +110,7 @@ readonly class CsvFile implements SeekableIterator
         $contents = (is_string($contents)) ? $contents : '';
         $values = array_map(
             static fn ($value): string => (is_scalar($value)) ? $value : '',
-            str_getcsv($contents),
+            str_getcsv($contents, escape: ''),
         );
         return $this->rowProcessor->execute($values);
     }

--- a/src/Utils/CsvFile.php
+++ b/src/Utils/CsvFile.php
@@ -19,10 +19,10 @@ readonly class CsvFile implements SeekableIterator
 {
     private SplFileObject $file;
 
-    private ArrayProcessorInterface $rowProcessor;
-
-    public function __construct(string $filename, ArrayProcessorInterface|null $rowProcessor = null)
-    {
+    public function __construct(
+        string $filename,
+        private ArrayProcessorInterface $rowProcessor = new NullArrayProcessor(),
+    ) {
         if ('' === $filename) {
             throw new UnexpectedValueException('The filename cannot be empty');
         }
@@ -30,7 +30,6 @@ readonly class CsvFile implements SeekableIterator
             throw new UnexpectedValueException('The filename is a directory');
         }
         $this->file = new SplFileObject($filename, 'r');
-        $this->rowProcessor = $rowProcessor ?? new NullArrayProcessor();
     }
 
     public function position(): int

--- a/src/Utils/ShellExec.php
+++ b/src/Utils/ShellExec.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCfdi\SatCatalogosPopulate\Utils;
 
-class ShellExec
+final class ShellExec
 {
     /** @param string[] $output */
     public function __construct(

--- a/src/Utils/WhichTrait.php
+++ b/src/Utils/WhichTrait.php
@@ -8,7 +8,7 @@ use RuntimeException;
 
 trait WhichTrait
 {
-    public function which(string $executable): string
+    public static function which(string $executable): string
     {
         $wichPath = '/usr/bin/which';
         if (! is_file($wichPath) || ! is_executable($wichPath)) {

--- a/tests/Features/Converters/XlsxToCsvFolderConverterTest.php
+++ b/tests/Features/Converters/XlsxToCsvFolderConverterTest.php
@@ -18,7 +18,7 @@ final class XlsxToCsvFolderConverterTest extends TestCase
         $destination = tempdir($this->utilFilePath(''));
 
         // when convert to csv files in a destination
-        $converter = new XlsxToCsvFolderConverter();
+        $converter = XlsxToCsvFolderConverter::create();
         $converter->convert($source, $destination);
 
         // then the expected files exist

--- a/tests/Features/ImportTest.php
+++ b/tests/Features/ImportTest.php
@@ -8,9 +8,11 @@ use PhpCfdi\SatCatalogosPopulate\Database\Repository;
 use PhpCfdi\SatCatalogosPopulate\Importers\CfdiCatalogs;
 use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Converters\FakeXlsToCsvFolder;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\NullLogger;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ImportTest extends TestCase
 {
     public function testImportCfdi(): void

--- a/tests/Features/Origins/Reviewers/ConstantReviewerTest.php
+++ b/tests/Features/Origins/Reviewers/ConstantReviewerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins\Reviewers;
 
 use DateTimeImmutable;
 use PhpCfdi\SatCatalogosPopulate\Origins\ConstantOrigin;
-use PhpCfdi\SatCatalogosPopulate\Origins\ConstantReviewer;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\ConstantReviewer;
 use PhpCfdi\SatCatalogosPopulate\Origins\UrlResponse;
 use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Origins\FakeGateway;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;

--- a/tests/Features/Origins/Reviewers/Nomina12eReviewerTest.php
+++ b/tests/Features/Origins/Reviewers/Nomina12eReviewerTest.php
@@ -7,7 +7,9 @@ namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins\Reviewers;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\Nomina12eReviewer;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 final class Nomina12eReviewerTest extends TestCase
 {
     public function testReviewerCanObtainTheUrlToDownload(): void

--- a/tests/Features/Origins/Reviewers/Nomina12eReviewerTest.php
+++ b/tests/Features/Origins/Reviewers/Nomina12eReviewerTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins\Reviewers;
+
+use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\Nomina12eReviewer;
+use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
+
+final class Nomina12eReviewerTest extends TestCase
+{
+    public function testReviewerCanObtainTheUrlToDownload(): void
+    {
+        $gateway = $this->createMock(ResourcesGatewayInterface::class);
+        $reviewer = new Nomina12eReviewer($gateway);
+        $url = $reviewer->obtainResourceUrl();
+        $this->assertMatchesRegularExpression('#^https://.*/cat_Nomina.*xls$#', $url);
+    }
+}

--- a/tests/Features/Origins/Reviewers/ReviewersTest.php
+++ b/tests/Features/Origins/Reviewers/ReviewersTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins\Reviewers;
 
 use DateTimeImmutable;
 use PhpCfdi\SatCatalogosPopulate\Origins\ConstantOrigin;
 use PhpCfdi\SatCatalogosPopulate\Origins\Origins;
-use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\Reviewers;
 use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Origins\FakeGateway;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 

--- a/tests/Features/Origins/Reviewers/ScrapingReviewerTest.php
+++ b/tests/Features/Origins/Reviewers/ScrapingReviewerTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Tests\Features\Origins\Reviewers;
 
 use DateTimeImmutable;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\ScrapingReviewer;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
-use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewer;
 use PhpCfdi\SatCatalogosPopulate\Origins\UrlResponse;
 use PhpCfdi\SatCatalogosPopulate\Tests\Fixtures\Origins\FakeGateway;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,6 +32,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
 
     public function utilMimeType(string $filename): string
     {
-        return (new finfo())->file($filename, FILEINFO_MIME_TYPE) ?: '';
+        return new finfo()->file($filename, FILEINFO_MIME_TYPE) ?: '';
     }
 }

--- a/tests/Unit/Origins/ConstantReviewerTest.php
+++ b/tests/Unit/Origins/ConstantReviewerTest.php
@@ -10,7 +10,9 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ConstantReviewer;
 use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ConstantReviewerTest extends TestCase
 {
     private ConstantReviewer $reviewer;

--- a/tests/Unit/Origins/Reviewers/ConstantReviewerTest.php
+++ b/tests/Unit/Origins/Reviewers/ConstantReviewerTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Origins\Reviewers;
 
 use LogicException;
 use PhpCfdi\SatCatalogosPopulate\Origins\ConstantOrigin;
-use PhpCfdi\SatCatalogosPopulate\Origins\ConstantReviewer;
 use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\ConstantReviewer;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 

--- a/tests/Unit/Origins/Reviewers/ScrapingReviewerTest.php
+++ b/tests/Unit/Origins/Reviewers/ScrapingReviewerTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Origins;
+namespace PhpCfdi\SatCatalogosPopulate\Tests\Unit\Origins\Reviewers;
 
 use LogicException;
 use PhpCfdi\SatCatalogosPopulate\Origins\OriginInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
+use PhpCfdi\SatCatalogosPopulate\Origins\Reviewers\ScrapingReviewer;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
-use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewer;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 

--- a/tests/Unit/Origins/ScrapingReviewerTest.php
+++ b/tests/Unit/Origins/ScrapingReviewerTest.php
@@ -10,7 +10,9 @@ use PhpCfdi\SatCatalogosPopulate\Origins\ResourcesGatewayInterface;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingOrigin;
 use PhpCfdi\SatCatalogosPopulate\Origins\ScrapingReviewer;
 use PhpCfdi\SatCatalogosPopulate\Tests\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 
+#[AllowMockObjectsWithoutExpectations]
 final class ScrapingReviewerTest extends TestCase
 {
     private ScrapingReviewer $reviewer;


### PR DESCRIPTION
This is an update to be able to download *Nóminas 1.2 revisión E* catalog file.
The resource URL requires a web browser that executes *javascript*.

*Chrome* or *Chromium* is now required to obtain the resource address for *Nóminas 1.2 revisión E*.
This version add `chrome-php/chrome` as a dependency.
If chrome is not executable or detectable you can set the binary location on `CHROME_BINARY` variable.

On this version, *Origin reviewers* change its namespace from
`PhpCfdi\SatCatalogosPopulate\Origins` to `PhpCfdi\SatCatalogosPopulate\Origins\Reviewers`.

Minimal PHP version is now 8.4.
Compatibility with PHP 8.5 has been included.

Function `str_getcsv` parameter `escape` bas been defined as empty string.
All other values are deprecated.

All classes that has the chance has been maked as `final` or `readonly`.

Other changes:

- PHPUnit has been upgrated to 12.5.
