### PR TITLE
Fix Hidrocarburos y petrolíferos 1.0 scraper (version 4.0.1)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        php-versions: ['8.4', '8.5']
+        php-version: ['8.4', '8.5']
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # phpcfdi/sat-catalogos-populate Changelog
 
+## Version 4.0.1 2026-04-06
+
+This is a fix to get *Hidrocarburos y petrolíferos 1.0* catalog file since it fails on scraping,
+looks like the dialog was not opened. It was fixed specifying the browser screen size.
+
+This update algo fixes an error message that was incorrectly saying *Nominas 12E* when it has to say
+*Hidrocarburos y petrolíferos 1.0*.
+
+Other minimal changes:
+
+- Fix variable name `php-versions` to `php-version` on GitHub workflow `tests`.
+
 ## Version 4.0.0 2026-04-06
 
 This is an update to be able to download *Hidrocarburos y petrolíferos 1.0* catalog file.

--- a/src/Origins/Reviewers/HidroPetro10Reviewer.php
+++ b/src/Origins/Reviewers/HidroPetro10Reviewer.php
@@ -38,7 +38,10 @@ final class HidroPetro10Reviewer implements ReviewerInterface
         try {
             $resourceUrl = $this->obtainResourceUrl();
         } catch (Exception $exception) {
-            throw new RuntimeException('Unable to obtain resource URL for Hidrocarburos y petrolíferos 1.0', previous: $exception);
+            throw new RuntimeException(
+                'Unable to obtain resource URL for Hidrocarburos y petrolíferos 1.0',
+                previous: $exception,
+            );
         }
 
         $origin = new ConstantOrigin(

--- a/src/Origins/Reviewers/HidroPetro10Reviewer.php
+++ b/src/Origins/Reviewers/HidroPetro10Reviewer.php
@@ -38,7 +38,7 @@ final class HidroPetro10Reviewer implements ReviewerInterface
         try {
             $resourceUrl = $this->obtainResourceUrl();
         } catch (Exception $exception) {
-            throw new RuntimeException('Unable to obtain resource URL for Nómina 1.2E', previous: $exception);
+            throw new RuntimeException('Unable to obtain resource URL for Hidrocarburos y petrolíferos 1.0', previous: $exception);
         }
 
         $origin = new ConstantOrigin(

--- a/src/Origins/Reviewers/HidroPetro10Reviewer.php
+++ b/src/Origins/Reviewers/HidroPetro10Reviewer.php
@@ -56,7 +56,11 @@ final class HidroPetro10Reviewer implements ReviewerInterface
     {
         $chromeBinary = $this->obtainChromeBinary();
         $browserFactory = new BrowserFactory($chromeBinary);
-        $browserFactory->addOptions(['noSandbox' => $this->obtainChromeNoSandbox()]);
+        $browserFactory->addOptions([
+            // 'headless' => false, // for development/debug
+            'noSandbox' => $this->obtainChromeNoSandbox(),
+            'windowSize' => [1600, 900],
+        ]);
         $browser = $browserFactory->createBrowser();
         try {
             // creates a new page and navigate to a URL


### PR DESCRIPTION
This is a fix to get *Hidrocarburos y petrolíferos 1.0* catalog file since it fails on scraping,
looks like the dialog was not opened. It was fixed specifying the browser screen size.

This update algo fixes an error message that was incorrectly saying *Nominas 12E* when it has to say
*Hidrocarburos y petrolíferos 1.0*.

Other minimal changes:

- Fix variable name `php-versions` to `php-version` on GitHub workflow `tests`.